### PR TITLE
Automatic build of a multi-arch Docker image with Travis CI (also for Raspberry Pi)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
             - sourceline: 'deb https://download.docker.com/linux/ubuntu/ xenial stable'
               key_url: 'https://download.docker.com/linux/ubuntu/gpg'
           packages:
+            - qemu-user
             - docker-ce
             - docker-ce-cli
             - containerd.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,9 @@
 language: python
 sudo: required
 dist: xenial
-addons:
-  apt:
-    sources:
-    - sourceline: 'deb https://download.docker.com/linux/ubuntu/ xenial stable'
-      key_url: 'https://download.docker.com/linux/ubuntu/gpg'
-    packages:
-    - docker-ce
-    - docker-ce-cli
-    - containerd.io
 jobs:
   include:
-    - stage: Test
+    - stage: test
       python:
         - '3.5'
         - '3.6'
@@ -21,5 +12,20 @@ jobs:
         - pip install .
         - pip install -r requirements.txt
       script: python setup.py test
-    - stage: Docker Image
-      script: export DOCKER_CLI_EXPERIMENTAL=enabled&&docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .
+    - stage: docker
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb https://download.docker.com/linux/ubuntu/ xenial stable'
+              key_url: 'https://download.docker.com/linux/ubuntu/gpg'
+          packages:
+            - docker-ce
+            - docker-ce-cli
+            - containerd.io
+      script:
+        - export DOCKER_CLI_EXPERIMENTAL=enabled
+        - docker buildx create --use
+        - docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .
+  stages:
+    - test
+    - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 addons:
   apt:
     sources:
-    - sourceline: 'deb https://download.docker.com/linux/ubuntu/xenial stable'
+    - sourceline: 'deb https://download.docker.com/linux/ubuntu/ xenial stable'
       key_url: 'https://download.docker.com/linux/ubuntu/gpg'
     packages:
     - docker-ce

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: python
 sudo: required
 dist: xenial
 jobs:
   include:
     - stage: test
+      language: python
       python:
         - '3.5'
         - '3.6'
@@ -20,9 +20,12 @@ jobs:
               key_url: 'https://download.docker.com/linux/ubuntu/gpg'
           packages:
             - qemu-user
+            - qemu-user-binfmt            
             - docker-ce
             - docker-ce-cli
             - containerd.io
+      language: python
+      python: '3.6'
       script:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
         - docker buildx create --use

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,10 @@ jobs:
       language: python
       python: '3.6'
       script:
+        - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+        - export DOCKER_IMAGE_TAG=$(if [ "$BRANCH" == "master" ]; then echo "latest"; else echo "dev-latest"; fi)
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - export DOCKER_CLI_EXPERIMENTAL=enabled
         - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         - docker buildx create --use
-        - docker buildx build --progress plain --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .
+        - docker buildx build --progress plain --platform linux/amd64,linux/arm64,linux/arm/v7 -t $DOCKER_USERNAME/pai:$DOCKER_IMAGE_TAG . --push

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       python: '3.6'
       script:
         - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-        - export DOCKER_IMAGE_TAG=$(if [ "$BRANCH" == "master" ]; then echo "latest"; else echo "dev-latest"; fi)
+        - export DOCKER_IMAGE_TAG=$(if [ "$BRANCH" == "master" ]; then echo "latest"; else echo "$BRANCH-latest"; fi)
         - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
         - export DOCKER_CLI_EXPERIMENTAL=enabled
         - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ jobs:
     - stage: test
       language: python
       python:
-        - '3.5'
-        - '3.6'
-        - '3.7'
+      - '3.5'
+      - '3.6'
+      - '3.7'
       install:
-        - pip install .
-        - pip install -r requirements.txt
+      - pip install .
+      - pip install -r requirements.txt
       script: python setup.py test
     - stage: docker
       addons:
@@ -19,8 +19,6 @@ jobs:
             - sourceline: 'deb https://download.docker.com/linux/ubuntu/ xenial stable'
               key_url: 'https://download.docker.com/linux/ubuntu/gpg'
           packages:
-            - qemu-user
-            - qemu-user-binfmt            
             - docker-ce
             - docker-ce-cli
             - containerd.io
@@ -30,7 +28,7 @@ jobs:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
         - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         - docker buildx create --use
-        - docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .
+        - docker buildx build --progress tty --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .
   stages:
     - test
     - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,25 @@
 language: python
 sudo: required
 dist: xenial
-python:
-- '3.5'
-- '3.6'
-- '3.7'
-install:
-- pip install .
-- pip install -r requirements.txt
-script: python setup.py test
+addons:
+  apt:
+    sources:
+    - sourceline: 'deb https://download.docker.com/linux/ubuntu/xenial stable'
+      key_url: 'https://download.docker.com/linux/ubuntu/gpg'
+    packages:
+    - docker-ce
+    - docker-ce-cli
+    - containerd.io
+jobs:
+  include:
+    - stage: Test
+      python:
+        - '3.5'
+        - '3.6'
+        - '3.7'
+      install:
+        - pip install .
+        - pip install -r requirements.txt
+      script: python setup.py test
+    - stage: Docker Image
+      script: export DOCKER_CLI_EXPERIMENTAL=enabled&&docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ jobs:
       python: '3.6'
       script:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
+        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         - docker buildx create --use
         - docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .
   stages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ script: python setup.py test
 jobs:
   include:
     - stage: deploy
+      if: type != pull_request
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,17 @@
 sudo: required
 dist: xenial
+language: python
+python:
+  - '3.5'
+  - '3.6'
+  - '3.7'
+install:
+  - pip install .
+  - pip install -r requirements.txt
+  script: python setup.py test
 jobs:
   include:
-    - stage: test
-      language: python
-      python:
-      - '3.5'
-      - '3.6'
-      - '3.7'
-      install:
-      - pip install .
-      - pip install -r requirements.txt
-      script: python setup.py test
-    - stage: docker
+    - stage: deploy
       addons:
         apt:
           sources:
@@ -28,7 +27,4 @@ jobs:
         - export DOCKER_CLI_EXPERIMENTAL=enabled
         - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
         - docker buildx create --use
-        - docker buildx build --progress tty --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .
-  stages:
-    - test
-    - docker
+        - docker buildx build --progress plain --platform linux/amd64,linux/arm64,linux/arm/v7 -t batvanyovanistia/pai .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - pip install .
   - pip install -r requirements.txt
-  script: python setup.py test
+script: python setup.py test
 jobs:
   include:
     - stage: deploy


### PR DESCRIPTION
See #72.

A few notes: 
- This is a pull request for the master branch, but given that there are no changes of `.travis.yaml` in master vs dev, I think it can be pushed to all branches
- The approach taken is the one outlined [here](https://github.com/ParadoxAlarmInterface/pai/issues/72#issuecomment-557909602)
- I've tested the resulting image (master branch only) under arm32v7 (with latest Raspbian on RPI4) and on a regular x86_64 under Ubuntu Bionic. Both seem to work without issues (that is, putting asside some issues in the Python code itself with my EVOHD)
- The script is not only building the Docker image, but also pushing it to Docker Hub, on successful build
- The image will automatically have the regular "latest" tag if it is built from master, and for all other branches, it will have a "branch-name"-latest tag attached to it. E.g. if pushed to the dev branch, it will build an image with a tag "dev-latest"
- The Travis  configuration requires two (encrypted!) environment variables, DOCKER_USERNAME, and DOCKER_PASSWORD. You have to create these on the Travis Settings page. Make them available for all branches, and make sure that they are encrypted.
- If you assign as a DOCKER_USERNAME 'jpbarraca', the script WILL overwrite the existing jpbarraca/pai image in Docker Hub. That's probably what we want anyway, once you feel comfortable with the changes.
- Let me know if you plan to do versioned builds in future. We can figure out the proper Docker tags for that.