### PR TITLE
TLS connection

### DIFF
--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -68,6 +68,8 @@ import logging
 # MQTT_ENABLE = False			# Enable MQTT Interface
 # MQTT_HOST = '127.0.0.1' 		# Hostname or address
 # MQTT_PORT = 1883        		# TCP Port
+# MQTT_TLS_PORT = 8883 			# TLS Port
+# MQTT_TLS_CERT_PATH = None		# Path to ca cert (/etc/pai/certs/ca.pem)
 # MQTT_KEEPALIVE = 60     		# Keep alive
 # MQTT_USERNAME = None    		# MQTT Username for authentication
 # MQTT_PASSWORD = None    		# MQTT Password

--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -67,9 +67,8 @@ import logging
 ### MQTT
 # MQTT_ENABLE = False			# Enable MQTT Interface
 # MQTT_HOST = '127.0.0.1' 		# Hostname or address
-# MQTT_PORT = 1883        		# TCP Port
-# MQTT_TLS_PORT = 8883 			# TLS Port
-# MQTT_TLS_CERT_PATH = None		# Path to ca cert (/etc/pai/certs/ca.pem)
+# MQTT_PORT = 1883        		# TCP Port (TLS port if MQTT_TLS_CERT_PATH is set)
+# MQTT_TLS_CERT_PATH = None		# Path to ca cert (/etc/pai/certs/ca.pem), if you want TLS
 # MQTT_KEEPALIVE = 60     		# Keep alive
 # MQTT_USERNAME = None    		# MQTT Username for authentication
 # MQTT_PASSWORD = None    		# MQTT Password

--- a/paradox/config.py
+++ b/paradox/config.py
@@ -83,6 +83,8 @@ class Config(object):
         "MQTT_ENABLE": False,  # Enable MQTT Interface
         "MQTT_HOST": "127.0.0.1",  # Hostname or address
         "MQTT_PORT": (1883, int, (1, 65535)),  # TCP Port
+        "MQTT_TLS_PORT": (8883, int, (1, 65535)),    # TLS Port
+        "MQTT_TLS_CERT_PATH" : (None, [str, type(None)]),  # Path to ca cert (/etc/pai/certs/ca.pem)
         "MQTT_KEEPALIVE": (60, int, (1, 3600)),  # Keep alive
         "MQTT_USERNAME": (None, [str, type(None)]),  # MQTT Username for authentication
         "MQTT_PASSWORD": (None, [str, type(None)]),  # MQTT Password

--- a/paradox/config.py
+++ b/paradox/config.py
@@ -82,9 +82,8 @@ class Config(object):
         # MQTT
         "MQTT_ENABLE": False,  # Enable MQTT Interface
         "MQTT_HOST": "127.0.0.1",  # Hostname or address
-        "MQTT_PORT": (1883, int, (1, 65535)),  # TCP Port
-        "MQTT_TLS_PORT": (8883, int, (1, 65535)),    # TLS Port
-        "MQTT_TLS_CERT_PATH" : (None, [str, type(None)]),  # Path to ca cert (/etc/pai/certs/ca.pem)
+        "MQTT_PORT": (1883, int, (1, 65535)),  # TCP Port (TLS port if MQTT_TLS_CERT_PATH is set)
+        "MQTT_TLS_CERT_PATH" : (None, [str, type(None)]),  # Path to ca cert (/etc/pai/certs/ca.pem), if you want TLS
         "MQTT_KEEPALIVE": (60, int, (1, 3600)),  # Keep alive
         "MQTT_USERNAME": (None, [str, type(None)]),  # MQTT Username for authentication
         "MQTT_PASSWORD": (None, [str, type(None)]),  # MQTT Password

--- a/paradox/interfaces/mqtt/core.py
+++ b/paradox/interfaces/mqtt/core.py
@@ -83,7 +83,7 @@ class MQTTConnection(Client):
         if cfg.MQTT_USERNAME is not None and cfg.MQTT_PASSWORD is not None:
             self.username_pw_set(username=cfg.MQTT_USERNAME, password=cfg.MQTT_PASSWORD)
 
-        if cfg.MQTT_TLS_CERT_PATH is not None and cfg.MQTT_TLS_PORT is not None:
+        if cfg.MQTT_TLS_CERT_PATH is not None:
             self.tls_set(ca_certs=cfg.MQTT_TLS_CERT_PATH,
                 certfile=None,
                 keyfile=None,

--- a/paradox/interfaces/mqtt/core.py
+++ b/paradox/interfaces/mqtt/core.py
@@ -123,17 +123,13 @@ class MQTTConnection(Client):
 
     def start(self):
         if self.state == ConnectionState.NEW:
-            if cfg.MQTT_TLS_CERT_PATH is not None and cfg.MQTT_TLS_PORT is not None:
-                PORT = cfg.MQTT_TLS_PORT
-            else:
-                PORT = cfg.MQTT_PORT
             self.loop_start()
 
             # TODO: Some initial connection retry mechanism required
             try:
                 self.connect_async(
                     host=cfg.MQTT_HOST,
-                    port=PORT,
+                    port=cfg.MQTT_PORT,
                     keepalive=cfg.MQTT_KEEPALIVE,
                     bind_address=cfg.MQTT_BIND_ADDRESS,
                     bind_port=cfg.MQTT_BIND_PORT,


### PR DESCRIPTION
@yozik04 
> @jakezp if you tell me how to configure paho mqtt with TLS support it will be easy to add...

I've managed to get PAI connect to my broker using TLS... Messed around a lot until it connected. It's probably not really how you'd want to incorporate it, but I've created a pull request. Have a look and you can rewrite it. But it's an example of how I got it to work :)

PAI log entry:
```
2020-07-14 22:52:16,514 - INFO     - Thread-1   - PAI.paradox.interfaces.mqtt.core - MQTT Broker Connected
```
mosquitto mqtt log entry:
```
1594767136: New connection from 192.168.1.75 on port 8883.
1594767136: New client connected from 192.168.1.75 as paradox_mqtt/69ec85798a1d5ff6 (p2, c1, k60, u'paradox')
```