### PR TITLE
Fix directory change in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 set -e
 
-cd "${0%/*}"
+cd "$(dirname "$0")"
 python3 -m paradox.console_scripts.pai_run "$@"


### PR DESCRIPTION
With the previous version having `run.sh` in the global path or calling it using `sh run.sh` would result in `cd runs.sh` and the directory change would fail together with the whole script (due to `set -e`).