### PR TITLE
Fix codec search for python3.9+

### DIFF
--- a/paradox/lib/encodings/__init__.py
+++ b/paradox/lib/encodings/__init__.py
@@ -10,7 +10,7 @@ codec_cache = {}
 
 def paradox_codec_search(name: str):
     name = name.lower()
-    match = re.match("^paradox-([a-z]{2})$", name)
+    match = re.match("^paradox[-_]([a-z]{2})$", name)
     if match:
         enc = match.group(1)
         mod = codec_cache.get(enc)


### PR DESCRIPTION
The encoding normalization during lookup has changed in python3.9 ( 20f59fe1f7748ae899aceee4cb560e5e1f528a1f ) to replace dashes with underscores.

Sample test script:

```python
import codecs


def loggin_search_function(encoding_name):
    print(f"Looking up {encoding_name}")
    return None

codecs.register(loggin_search_function)

try:
    b'test'.decode('som-dashed-ENCODING')
except LookupError:
    pass

"""
$ python3.6 test.py
Looking up some-dashed-encoding
$ python3.7 test.py
Looking up some-dashed-encoding
$ python3.8 test.py
Looking up some-dashed-encoding
$ python3.9 test.py
Looking up some_dashed_encoding
"""
```

P.S. The `.lower()` seems also to not be needed for the python3.6+

P.S.2 Is there any reason why py3.9 is not in travis.yaml ?