### PR TITLE
Handle TypeError exception if numeric states are published

### DIFF
--- a/paradox/interfaces/mqtt/basic.py
+++ b/paradox/interfaces/mqtt/basic.py
@@ -445,7 +445,11 @@ class BasicMQTTInterface(AbstractMQTTInterface):
             return
 
         if cfg.MQTT_USE_NUMERIC_STATES:
-            publish_value = int(value)
+            try:
+                publish_value = int(value)
+            except TypeError:
+                logger.debug('Conversion int(%s) failed, use original value', value)
+                publish_value = value
         else:
             publish_value = value
 


### PR DESCRIPTION
If publishing values can not be converted to integer, it publishes original value.

It closes #287.

Thanks.