### PR TITLE
How to synchronize panel time on another timezone than the local one

### DIFF
--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -56,6 +56,7 @@ import logging
 # OUTPUT_PULSE_DURATION = 1               # Duration of a PGM pulse in seconds
 # SYNC_TIME = False    			# Update panel time periodically when time drifts more than SYNC_TIME_MIN_DRIFT
 # SYNC_TIME_MIN_DRIFT = 60    	# Minimum time drift in seconds to initiate time sync
+# PANEL_TIMEZONE=''             # Timezone used for panel time synchronisation. PAI host timezone is used by default
 # PASSWORD = '0000'   			# PC Password. Set to None if Panel has no Password.
 #                                 # In Babyware: Right click on your panel -> Properties -> PC Communication (Babyware) ->
 #                                 # PC Communication (Babyware) Tab.

--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -56,7 +56,7 @@ import logging
 # OUTPUT_PULSE_DURATION = 1               # Duration of a PGM pulse in seconds
 # SYNC_TIME = False    			# Update panel time periodically when time drifts more than SYNC_TIME_MIN_DRIFT
 # SYNC_TIME_MIN_DRIFT = 60    	# Minimum time drift in seconds to initiate time sync
-# PANEL_TIMEZONE=''             # Timezone used for panel time synchronisation. PAI host timezone is used by default
+# SYNC_TIME_TIMEZONE=''             # Timezone used for panel time synchronisation. PAI host timezone is used by default
 # PASSWORD = '0000'   			# PC Password. Set to None if Panel has no Password.
 #                                 # In Babyware: Right click on your panel -> Properties -> PC Communication (Babyware) ->
 #                                 # PC Communication (Babyware) Tab.

--- a/paradox/config.py
+++ b/paradox/config.py
@@ -71,9 +71,9 @@ class Config(object):
         "SYNC_TIME_MIN_DRIFT": (
                 120,
                 int,
-                (60, 0xFFFFFFFF)
+                (120, 0xFFFFFFFF)
         ), # Minimum time drift in seconds to initiate time sync
-        "PANEL_TIMEZONE": "",  # Panel use same timezone as pai host
+        "SYNC_TIME_TIMEZONE": "",  # By default pai uses the same timezone as pai host
         "PASSWORD": (
             None,
             [int, str, bytes, type(None)],

--- a/paradox/config.py
+++ b/paradox/config.py
@@ -73,6 +73,7 @@ class Config(object):
                 int,
                 (60, 0xFFFFFFFF)
         ), # Minimum time drift in seconds to initiate time sync
+        "PANEL_TIMEZONE": "",  # Panel use same timezone as pai host
         "PASSWORD": (
             None,
             [int, str, bytes, type(None)],

--- a/paradox/paradox.py
+++ b/paradox/paradox.py
@@ -246,12 +246,12 @@ class Paradox:
 
     async def sync_time(self):
         now = datetime.now().astimezone()
-        if cfg.PANEL_TIMEZONE:
+        if cfg.SYNC_TIME_TIMEZONE:
             try:
-                tzinfo = pytz.timezone(cfg.PANEL_TIMEZONE)
+                tzinfo = pytz.timezone(cfg.SYNC_TIME_TIMEZONE)
                 now = now.astimezone(tzinfo)
             except pytz.exceptions.UnknownTimeZoneError:
-                logger.debug(f"Panel Timezone Unknown ('{cfg.PANEL_TIMEZONE}'). Skipping sync")
+                logger.debug(f"Panel Timezone Unknown ('{cfg.SYNC_TIME_TIMEZONE}'). Skipping sync")
                 return
 
         if not self._is_time_sync_required(now.replace(tzinfo=None)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ require-python-3
 construct~=2.9.43
 argparse>=1.4.0
 python-slugify>=4.0.1
+pytz>=2021.3
+tzlocal>=4.1
 #
 # Optional
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ construct~=2.9.43
 argparse>=1.4.0
 python-slugify>=4.0.1
 pytz>=2021.3
-tzlocal>=4.1
 #
 # Optional
 #


### PR DESCRIPTION
Hello,

I propose a solution to synchonize the panel on another timezone than the local one.
For example, PAI can run on a UTC host and the panel be in CET timezone
Tested on EVO192 and Raspberry under Bullseye
The config file is using pytz timezone

In case you are interested in.
Regards,
Benoit