### PR TITLE
Support for serial server Moxa nPort 5100

### DIFF
--- a/paradox/__init__.py
+++ b/paradox/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "3.1.0-dev"
+VERSION = "3.0.1"


### PR DESCRIPTION
Support remote serial port over ethernet as Moxa nPort 5100 or Advantech ADAM 4571, this devices is supported only with OS drivers ( linux, windows ) and creates virtual serial port in OS.
Moxa supporting mode as reverse telnet and maybe it could be implemented in PAI.
Thank you
![Moxa-NPort5110-12573455-01](https://user-images.githubusercontent.com/76579362/183616252-0a29e521-d145-42ba-bcb6-0d968e5fa556.jpg)
.