### PR TITLE
Treat arm_no_entry as armed_night state

### DIFF
--- a/paradox/paradox.py
+++ b/paradox/paradox.py
@@ -777,7 +777,7 @@ class Paradox:
             elif properties.get("arm"):
                 if properties.get("arm_stay"):
                     change["current_state"] = "armed_home"
-                elif properties.get("arm_sleep"):
+                elif properties.get("arm_sleep") or properties.get("arm_no_entry"):
                     change["current_state"] = "armed_night"
                 elif properties.get("arm_away"):
                     change["current_state"] = "armed_away"


### PR DESCRIPTION
I use instant arm to arm zones for night (this is how installer of alarm system instructed me to do loong time ago, and I didn't find other way how to sleep-arm zones, some of mine keypads have sleep button, but, when pressed it says "Function is not available", I don't know if it is related to quite an old firmware EVO192 is running - 2.50 build 3). 
Now, to instant_arm from home assistant for night mode, I have added alias in pai.conf file:
```
MQTT_COMMAND_ALIAS = {
    'arm_sleep': 'arm_instant',
}
```
This works fine, but when armed in instant mode, home assistant shows zone as 'Armed away', while 'Armed night'  better corresponds to the actual arming type when arm_no_entry is set to True.