### PR TITLE
Add the possibility to prefix entites with device name

### DIFF
--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -81,7 +81,6 @@ import logging
 # MQTT_BIND_PORT = 0            # MQTT Client bind port. Default: 0 - pick automatically
 # MQTT_REPUBLISH_INTERVAL = 60 * 60 * 12  # Interval for republishing all data
 # MQTT_PUBLISH_DEFINITIONS = False        # Publish definitions of partitions/zones/users to MQTT. Not required in most cases.
-# MQTT_PREFIX_DEVICE_NAME = False         # Add device ID as prefix to entity names: Paradox 12345678
 #
 ### MQTT Topics
 # MQTT_BASE_TOPIC = 'paradox'             # Root of all topics
@@ -96,6 +95,7 @@ import logging
 # MQTT_CONTROL_TOPIC = 'control'          # Base for control of other elements (ROOT/CONTROL/TYPE)
 # MQTT_DEFINITIONS_TOPIC = 'control'      # Base for definitions
 # MQTT_HOMEASSISTANT_DISCOVERY_PREFIX = 'homeassistant'
+# MQTT_HOMEASSISTANT_ENTITY_PREFIX = ''   # If you want to prefix all entities you can use: "Paradox {serial_number} ", placeholders "serial_number" and "model" are supported. Default: "" - no prefix
 # MQTT_OUTPUT_TOPIC = 'outputs'
 # MQTT_DOOR_TOPIC = 'doors'
 # MQTT_KEYPAD_TOPIC = 'keypads'

--- a/config/pai.conf.example
+++ b/config/pai.conf.example
@@ -81,6 +81,7 @@ import logging
 # MQTT_BIND_PORT = 0            # MQTT Client bind port. Default: 0 - pick automatically
 # MQTT_REPUBLISH_INTERVAL = 60 * 60 * 12  # Interval for republishing all data
 # MQTT_PUBLISH_DEFINITIONS = False        # Publish definitions of partitions/zones/users to MQTT. Not required in most cases.
+# MQTT_PREFIX_DEVICE_NAME = False         # Add device ID as prefix to entity names: Paradox 12345678
 #
 ### MQTT Topics
 # MQTT_BASE_TOPIC = 'paradox'             # Root of all topics

--- a/paradox/config.py
+++ b/paradox/config.py
@@ -136,6 +136,7 @@ class Config(object):
         "MQTT_SEND_PANIC_TOPIC": "panic",
         "MQTT_PUBLISH_RAW_EVENTS": True,
         "MQTT_PUBLISH_DEFINITIONS": False,  # Publish definitions of partitions/zones/users to mqtt.
+        "MQTT_PREFIX_DEVICE_NAME": False,  # Add device ID as prefix to entity names: Paradox 12345678
         "MQTT_INTERFACE_TOPIC": "interface",
         "MQTT_TOGGLE_CODES": {},
         "MQTT_USE_NUMERIC_STATES": False,  # use 0 and 1 instead of True and False

--- a/paradox/config.py
+++ b/paradox/config.py
@@ -1,10 +1,10 @@
 import logging
 import os
-import sys
 import re
+import sys
 
 
-class Config(object):
+class Config:
     DEFAULTS = {
         "LOGGING_LEVEL_CONSOLE": logging.INFO,  # See documentation of Logging package
         "LOGGING_LEVEL_FILE": logging.ERROR,
@@ -69,10 +69,10 @@ class Config(object):
         ),  # Duration of a PGM pulse in seconds
         "SYNC_TIME": False,  # Update panel time periodically when time drifts more than SYNC_TIME_MIN_DRIFT
         "SYNC_TIME_MIN_DRIFT": (
-                120,
-                int,
-                (120, 0xFFFFFFFF)
-        ), # Minimum time drift in seconds to initiate time sync
+            120,
+            int,
+            (120, 0xFFFFFFFF),
+        ),  # Minimum time drift in seconds to initiate time sync
         "SYNC_TIME_TIMEZONE": "",  # By default pai uses the same timezone as pai host
         "PASSWORD": (
             None,
@@ -101,7 +101,11 @@ class Config(object):
         "MQTT_USERNAME": (None, [str, type(None)]),  # MQTT Username for authentication
         "MQTT_PASSWORD": (None, [str, type(None)]),  # MQTT Password
         "MQTT_RETAIN": True,  # Publish messages with Retain
-        "MQTT_QOS": (0, int, (0, 2)),  # Publish messages with QOS level (0 - fire and forget, 1 - at least once, 2 - exactly once)
+        "MQTT_QOS": (
+            0,
+            int,
+            (0, 2),
+        ),  # Publish messages with QOS level (0 - fire and forget, 1 - at least once, 2 - exactly once)
         "MQTT_PROTOCOL": ("3.1.1", str, ("3.1", "3.1.1", "5")),  # Protocol to use
         "MQTT_TRANSPORT": ("tcp", str, ("tcp", "websockets")),  # Transport to use
         "MQTT_BIND_ADDRESS": "",  # MQTT Bind address (Paho default)
@@ -113,6 +117,7 @@ class Config(object):
         ),  # Interval for republishing all data
         "MQTT_HOMEASSISTANT_AUTODISCOVERY_ENABLE": False,
         "MQTT_HOMEASSISTANT_CODE": (None, [str, type(None)]),
+        "MQTT_HOMEASSISTANT_ENTITY_PREFIX": "",  # If you want to prefix all entities you can use: "Paradox {serial_number} ", placeholders "serial_number" and "model" are supported. Default: "" - no prefix
         # MQTT Topics
         "MQTT_BASE_TOPIC": "paradox",  # Root of all topics
         "MQTT_ZONE_TOPIC": "zones",  # Base for zone states
@@ -173,12 +178,12 @@ class Config(object):
             ["DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"],
         ),
         "HOMEASSISTANT_PUBLISH_PARTITION_PROPERTIES": [  # List of partition properties to publish
-            'target_state',
-            'current_state'
+            "target_state",
+            "current_state",
         ],
         "HOMEASSISTANT_PUBLISH_ZONE_PROPERTIES": [  # List of zone properties to publish
-            'open',
-            'tamper'
+            "open",
+            "tamper",
         ],
         "HOMEASSISTANT_NOTIFICATIONS_IGNORE_EVENTS": [],  # List of tuples or regexp matching "type,label,property=value,property2=value" eg. [(major, minor), "zone:HOME:entry_delay=True", ...]
         "HOMEASSISTANT_NOTIFICATIONS_ALLOW_EVENTS": [],  # Same as before but as a white list. Default is use EVENT_FILTERS
@@ -281,11 +286,7 @@ class Config(object):
     CONFIG_FILE_LOCATION = (None,)
 
     def __dir__(self):
-        return (
-            list(self.DEFAULTS.keys())
-            + list(self.__class__.__dict__)
-            + dir(super(Config, self))
-        )
+        return list(self.DEFAULTS.keys()) + list(self.__class__.__dict__) + dir(super())
 
     def __init__(self):
         self._reset_defaults()
@@ -315,9 +316,9 @@ class Config(object):
                 else:
                     default_type = [type(default)]
 
-                if float in default_type and not int in default_type:
+                if float in default_type and int not in default_type:
                     default_type.append(int)
-                if int in default_type and not float in default_type:
+                if int in default_type and float not in default_type:
                     default_type.append(float)
                 if type(v) in default_type:
                     setattr(self, k, v)
@@ -344,7 +345,7 @@ class Config(object):
                     if valid:
                         setattr(self, k, v)
                     else:
-                        err = "Error parsing configuration value: Invalid value for config argument {}. Allowed are: {}".format(
+                        err = "Error parsing configuration value: Invalid value type {} for config argument {}. Allowed are: {}".format(
                             type(v), k, expected_value
                         )
                         sys.stderr.write(err + "\n")
@@ -426,8 +427,9 @@ class Config(object):
 
 config = Config()
 
-comma_splitter_re = re.compile('\s*,\s*')
-range_re = re.compile('(\d+)\s*-(\d+)\s*$')
+comma_splitter_re = re.compile(r"\s*,\s*")
+range_re = re.compile(r"(\d+)\s*-(\d+)\s*$")
+
 
 def string_to_id_list(input: str):
     arr = []
@@ -443,6 +445,7 @@ def string_to_id_list(input: str):
                 pass
 
     return arr
+
 
 def get_limits_for_type(elem_type: str, default: list = None):
     limits = config.LIMITS.get(elem_type, default)

--- a/paradox/interfaces/mqtt/entities/abstract_entity.py
+++ b/paradox/interfaces/mqtt/entities/abstract_entity.py
@@ -40,7 +40,7 @@ class AbstractEntity:
         return dict(
             availability_topic=self.availability_topic,
             device=self.device,
-            name=f'{self.entity_name}',
+            name=f'Paradox {self.device.serial_number} {self.entity_name}' if cfg.MQTT_PREFIX_DEVICE_NAME else f'{self.entity_name}',
             unique_id=f'paradox_{self.device.serial_number}_{self.entity_id}',
             state_topic=self.state_topic,
         )

--- a/paradox/interfaces/mqtt/entities/abstract_entity.py
+++ b/paradox/interfaces/mqtt/entities/abstract_entity.py
@@ -1,11 +1,17 @@
 from paradox.config import config as cfg
-from paradox.interfaces.mqtt.helpers import get_control_topic_prefix, get_state_topic_prefix
+from paradox.interfaces.mqtt.entities.device import Device
+from paradox.interfaces.mqtt.helpers import (
+    get_control_topic_prefix,
+    get_state_topic_prefix,
+)
+
 
 def to_label(txt):
-    return txt.replace('_', ' ').title()
+    return txt.replace("_", " ").title()
+
 
 class AbstractEntity:
-    def __init__(self, device, availability_topic):
+    def __init__(self, device: Device, availability_topic):
         self.availability_topic = availability_topic
         self.device = device
 
@@ -28,20 +34,30 @@ class AbstractEntity:
 
     @property
     def configuration_topic(self):
-        return "/".join([
-            cfg.MQTT_HOMEASSISTANT_DISCOVERY_PREFIX,
-            self.hass_entity_type,
-            self.device.serial_number,
-            self.entity_id,
-            "config"
-        ])
+        return "/".join(
+            [
+                cfg.MQTT_HOMEASSISTANT_DISCOVERY_PREFIX,
+                self.hass_entity_type,
+                self.device.serial_number,
+                self.entity_id,
+                "config",
+            ]
+        )
 
     def serialize(self):
+        prefix = cfg.MQTT_HOMEASSISTANT_ENTITY_PREFIX.format(
+            {
+                "serial_number",
+                self.device.serial_number,
+                "model",
+                self.device.model,
+            }
+        )
         return dict(
             availability_topic=self.availability_topic,
             device=self.device,
-            name=f'Paradox {self.device.serial_number} {self.entity_name}' if cfg.MQTT_PREFIX_DEVICE_NAME else f'{self.entity_name}',
-            unique_id=f'paradox_{self.device.serial_number}_{self.entity_id}',
+            name=prefix + f"{self.entity_name}",
+            unique_id=f"paradox_{self.device.serial_number}_{self.entity_id}",
             state_topic=self.state_topic,
         )
 
@@ -59,7 +75,5 @@ class AbstractEntity:
 class AbstractControllableEntity(AbstractEntity):
     def serialize(self):
         config = super().serialize()
-        config.update(dict(
-            command_topic=self.command_topic
-        ))
+        config.update(dict(command_topic=self.command_topic))
         return config


### PR DESCRIPTION
It was removed in 4210d84df993e181825901122beb53bafede2c85.
The problem is that Home Assistant uses the name of the entity to generate it's `entity_id` and not the provided `unique_id`. This can result in identical entities in Home Assistant (if using auto discovery).

Or maybe an alternative to this would be to provide the value of `unique_id` in `object_id` as well. Reference: https://www.home-assistant.io/integrations/mqtt/#naming-of-mqtt-entities

Or maybe both? ;)