### PR TITLE
Expose numeric ids for MQTT definitions

### DIFF
--- a/paradox/interfaces/mqtt/basic.py
+++ b/paradox/interfaces/mqtt/basic.py
@@ -461,7 +461,8 @@ class BasicMQTTInterface(AbstractMQTTInterface):
                     if i not in labels:
                         continue
 
-                    for attribute in definitions[i]:  # attribute
+                    definition = {**(definitions[i]), "id": i}
+                    for attribute in definition:  # attribute
                         if element_type == "user" and attribute == "code":
                             continue
                         self._publish(
@@ -469,7 +470,7 @@ class BasicMQTTInterface(AbstractMQTTInterface):
                             element_type,
                             labels[i]["key"],
                             attribute,
-                            definitions[i][attribute],
+                            definition[attribute],
                         )
 
         if (


### PR DESCRIPTION
Add a numeric id to definitions (partitions, zones, users) published to MQTT.
This change allows matching zones (which expose a numeric "partition" value) to the corresponding partition.
The original definition is not mutated.