### PR TITLE
 Require Paho MQTT below 2.x version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ argparse>=1.4.0
 chump>=1.6.0
 construct~=2.9.43
 flake8
-paho_mqtt>=1.5.0
+paho_mqtt>=1.5.0,<2
 
 pre-commit
 pushbullet.py>=0.11.0


### PR DESCRIPTION
Same as 9dbe5bc.

```
pai  | 2024-04-18 18:35:15,978 - ERROR    - PAI.paradox.interfaces.interface_manager - Unable to start MQTT Interface
pai  | Traceback (most recent call last):
pai  |   File "/usr/local/lib/python3.9/site-packages/paradox/interfaces/interface_manager.py", line 37, in start
pai  |     self.register(BasicMQTTInterface(self.alarm))
pai  |   File "/usr/local/lib/python3.9/site-packages/paradox/interfaces/mqtt/basic.py", line 97, in __init__
pai  |     super().__init__(alarm)
pai  |   File "/usr/local/lib/python3.9/site-packages/paradox/interfaces/mqtt/core.py", line 231, in __init__
pai  |     self.mqtt = MQTTConnection.get_instance()
pai  |   File "/usr/local/lib/python3.9/site-packages/paradox/interfaces/mqtt/core.py", line 50, in get_instance
pai  |     cls._instance = MQTTConnection()
pai  |   File "/usr/local/lib/python3.9/site-packages/paradox/interfaces/mqtt/core.py", line 55, in __init__
pai  |     self.client = Client(
pai  |   File "/usr/local/lib/python3.9/site-packages/paho/mqtt/client.py", line 766, in __init__
pai  |     raise ValueError(
pai  | ValueError: Unsupported callback API version: version 2.0 added a callback_api_version, see migrations.md for details
```