### PR TITLE
Fix zone tamper trouble reset on EVO.

### DIFF
--- a/paradox/hardware/evo/event.py
+++ b/paradox/hardware/evo/event.py
@@ -371,7 +371,7 @@ event_map = {
         level=EventLevel.INFO,
         tags=["tamper", "restore"],
         type="zone",
-        change=dict(zone_tamper_trouble=True),
+        change=dict(zone_tamper_trouble=False),
         message="Zone {label} tamper restore",
     ),
     35: dict(


### PR DESCRIPTION
See issue #463.