### PR TITLE
Fix Pushover priority notifications

### DIFF
--- a/paradox/interfaces/text/pushover.py
+++ b/paradox/interfaces/text/pushover.py
@@ -58,6 +58,10 @@ class PushoverTextInterface(ConfiguredAbstractTextInterface):
         if device:
             params["device"] = device
 
+        if params["priority"] == 2:
+            params["retry"] = 30
+            params["expire"] = 10800
+
         conn.request(
             "POST",
             "/1/messages.json",


### PR DESCRIPTION
Hey everyone,

I recently noticed that I wasn’t receiving alarm trigger notifications via Pushover. The logs revealed a "Bad Request" error:

````
pai  | 2024-12-12 18:42:53,470 - INFO     - PAI.paradox.paradox - Running
pai  | 2024-12-12 18:52:04,950 - WARNING  - PAI.paradox.paradox - Missing property squawk in partition/Area 1
pai  | 2024-12-12 18:53:15,689 - ERROR    - PAI.paradox.interfaces.text.pushover - Failed to send message: Bad Request
pai  | 2024-12-12 18:53:16,614 - ERROR    - PAI.paradox.interfaces.text.pushover - Failed to send message: Bad Request
pai  | 2024-12-12 18:53:22,727 - INFO     - PAI.paradox.interfaces.text.pushover - Notification sent: Alarm cancelled by user System Master, level=INFO, device=all
````

After some investigation, I found that adding the `retry` and `expire` parameters to Pushover resolved the issue. These parameters are mandatory for "Emergency Priority" notifications according to the docs.

I'm not sure if it started failing because of a Pushover API update or when Chump was removed in 3.6.0 (commit 219e508ecb3915a4203dd97e37884a89c0109b4e), but the notifications started working again after this change. Here's the updated log after the fix:

````
pai  | 2024-12-12 18:53:43,202 - INFO     - PAI.paradox.paradox - Running
pai  | 2024-12-12 18:54:02,709 - WARNING  - PAI.paradox.paradox - Missing property squawk in partition/Area 1
pai  | 2024-12-12 18:55:09,623 - INFO     - PAI.paradox.interfaces.text.pushover - Notification sent: Partition Area 1 strobe active, level=CRITICAL, device=all
pai  | 2024-12-12 18:55:10,544 - INFO     - PAI.paradox.interfaces.text.pushover - Notification sent: Partition Area 1 steady alarm active, level=CRITICAL, device=all
pai  | 2024-12-12 18:55:16,048 - INFO     - PAI.paradox.interfaces.text.pushover - Notification sent: Alarm cancelled by user System Master, level=INFO, device=all
````