### PR TITLE
Fix parameters for _on_disconnect_cb

### DIFF
--- a/paradox/interfaces/mqtt/core.py
+++ b/paradox/interfaces/mqtt/core.py
@@ -200,7 +200,7 @@ class MQTTConnection():
         else:
             logger.error(f"Failed to connect to MQTT: {connack_string(result)} ({result})")
 
-    def _on_disconnect_cb(self, userdata, rc, properties=None):
+    def _on_disconnect_cb(self, client, userdata, rc, properties=None):
         # called on Thread-6
         if rc == MQTT_ERR_SUCCESS:
             logger.info("MQTT Broker Disconnected")


### PR DESCRIPTION
Fixes #546. See the expected callback function parameters [here](https://github.com/eclipse-paho/paho.mqtt.python/blob/9782ab81fe7ee3a05e74c7f3e1d03d5611ea4be4/src/paho/mqtt/client.py#L2087-L2094). Note that the parameters differ based on the MQTT protocol version, with MQTT 5 getting one additional parameter.

To test, run PAI, then restart the mqtt server, and monitor the logs.

Before, with `MQTT_PROTOCOL = "5"`:

```
ERROR    - Thread-1 (_thread_main) - PAI.paradox.interfaces.mqtt.core - Caught exception in on_disconnect: MQTTConnection._on_disconnect_cb() takes from 3 to 4 positional arguments but 5 were given: MQTTConnection._on_disconnect_cb() takes from 3 to 4 positional arguments but 5 were given
```

PAI never recovers from this error, staying disconnected.

Before, with `MQTT_PROTOCOL = "3.1.1"`:

```
ERROR    - PAI.paradox.interfaces.mqtt.core - MQTT Broker unexpectedly disconnected. Code: None
INFO     - PAI.paradox.interfaces.mqtt.core - MQTT Broker Connected
```

With this fix, on both protocol versions:

```
ERROR    - PAI.paradox.interfaces.mqtt.core - MQTT Broker unexpectedly disconnected. Code: 7
INFO     - PAI.paradox.interfaces.mqtt.core - MQTT Broker Connected
```

