### PR TITLE
fix(gsm): use shared line framing

### DIFF
--- a/paradox/connections/framing.py
+++ b/paradox/connections/framing.py
@@ -14,6 +14,9 @@ logger = logging.getLogger("PAI").getChild(__name__)
 # wasted memory per connection at 1 KB.
 COMPACT_THRESHOLD = 1024
 
+#: Default upper bound for a delimiter-framed line without a terminator.
+MAX_LINE_LENGTH = 512
+
 
 class _Signal:
     """A named singleton used as a non-frame framing outcome."""
@@ -165,6 +168,37 @@ class Framer(ABC):
     def _next_frame(self) -> Optional[Frame]:
         """Return the next frame, or ``None`` to wait for more data."""
         raise NotImplementedError
+
+
+class LineFramer(Framer):
+    """Split a byte stream on a terminator, keeping the terminator."""
+
+    def __init__(
+        self, terminator: bytes = b"\r", max_line_length: int = MAX_LINE_LENGTH
+    ) -> None:
+        super().__init__()
+        self._terminator = terminator
+        self._max_line_length = max_line_length
+
+    def _next_frame(self) -> Optional[Frame]:
+        """Return the next non-empty line, or ``None`` to wait for more data."""
+        while True:
+            index = self.buffer.pending.find(self._terminator)
+            if index < 0:
+                # Only now, with no complete line left to rescue, is a large
+                # buffer evidence of a lost terminator rather than of a burst
+                # of good lines still waiting to be extracted.
+                if len(self.buffer) > self._max_line_length:
+                    logger.warning(
+                        "Line framer buffer overflow (%d bytes), discarding",
+                        len(self.buffer),
+                    )
+                    self.buffer.clear()
+                return None
+
+            line = self.buffer.take(index + len(self._terminator))
+            if line[: -len(self._terminator)].strip():
+                return Frame(line)
 
 
 def checksum(data: bytes) -> bool:

--- a/paradox/connections/prt3/framing.py
+++ b/paradox/connections/prt3/framing.py
@@ -1,48 +1,5 @@
-"""Framing for the PRT3 ASCII line protocol.
+"""Backward-compatible imports for PRT3 line framing."""
 
-Pure byte handling: no asyncio, no transport.
-"""
+from paradox.connections.framing import MAX_LINE_LENGTH, LineFramer
 
-import logging
-
-from paradox.connections.framing import Frame, Framer
-
-logger = logging.getLogger("PAI").getChild(__name__)
-
-#: PRT3 lines are ~21 bytes; anything much larger means the delimiter was lost.
-MAX_LINE_LENGTH = 512
-
-
-class LineFramer(Framer):
-    """Splits a byte stream on a terminator, keeping the terminator."""
-
-    def __init__(
-        self, terminator: bytes = b"\r", max_line_length: int = MAX_LINE_LENGTH
-    ) -> None:
-        super().__init__()
-        self._terminator = terminator
-        self._max_line_length = max_line_length
-
-    def _next_frame(self):
-        """Return the next non-empty line, or ``None`` to wait for more data.
-
-        Lines with no printable content are skipped: a bare terminator carries
-        no message.
-        """
-        while True:
-            index = self.buffer.pending.find(self._terminator)
-            if index < 0:
-                # Only now, with no complete line left to rescue, is a large
-                # buffer evidence of a lost terminator rather than of a burst
-                # of good lines still waiting to be extracted.
-                if len(self.buffer) > self._max_line_length:
-                    logger.warning(
-                        "PRT3: buffer overflow (%d bytes), discarding",
-                        len(self.buffer),
-                    )
-                    self.buffer.clear()
-                return None
-
-            line = self.buffer.take(index + len(self._terminator))
-            if line[: -len(self._terminator)].strip():
-                return Frame(line)
+__all__ = ["MAX_LINE_LENGTH", "LineFramer"]

--- a/paradox/connections/prt3/protocol.py
+++ b/paradox/connections/prt3/protocol.py
@@ -15,8 +15,8 @@ import binascii
 import logging
 
 from paradox.config import config as cfg
+from paradox.connections.framing import LineFramer
 from paradox.connections.protocol_base import ConnectionProtocol
-from paradox.connections.prt3.framing import LineFramer
 
 logger = logging.getLogger("PAI").getChild(__name__)
 

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -8,6 +8,7 @@ import serial_asyncio
 
 from paradox.config import config as cfg
 from paradox.connections.connection import ConnectionProtocol
+from paradox.connections.framing import LineFramer
 from paradox.connections.handler import ConnectionHandler
 from paradox.event import EventLevel, Notification
 from paradox.interfaces.text.core import ConfiguredAbstractTextInterface
@@ -19,40 +20,39 @@ from paradox.lib import ps
 logger = logging.getLogger("PAI").getChild(__name__)
 
 
-class SerialConnectionProtocol(ConnectionProtocol):
+class GsmSerialProtocol(ConnectionProtocol):
     def __init__(self, handler: ConnectionHandler):
         super().__init__(handler)
         self.last_message = b""
-        self.buffer = b""
+        self._framer = LineFramer(terminator=b"\r\n")
 
     async def send_message(self, message):
         self.last_message = message
         self.transport.write(message + b"\r\n")
 
     def data_received(self, recv_data):
-        # Bytes arrive in arbitrary chunks, so partial lines are buffered until
-        # their CRLF terminator shows up in a later callback.
-        self.buffer += recv_data
-        logger.debug("BUFFER: %s", self.buffer)
-        while True:
-            r = self.buffer.find(b"\r\n")
-            if r < 0:  # No complete frame yet
-                break
+        for frame in self._framer.feed(recv_data):
+            message = frame.data[: -len(b"\r\n")]
+            logger.debug("GSM <- %s", message)
 
-            frame = self.buffer[:r]
-            self.buffer = self.buffer[r + 2 :]
-
-            if not frame:  # Empty line between frames
+            # A modem echo, when enabled, is the first non-empty line after a
+            # write. Clear the expectation even when that line is a response.
+            last_message, self.last_message = self.last_message, b""
+            if last_message and message.rstrip(b"\r") == last_message.rstrip(b"\r"):
                 continue
 
-            # Ignore echoed bytes
-            if self.last_message == frame:
-                self.last_message = b""
-            else:
-                self.handler.on_message(frame)  # Callback
+            try:
+                self.handler.on_message(message)
+            except Exception:
+                logger.exception("GSM message callback raised an exception")
 
     def reset_framing(self) -> None:
-        self.buffer = b""
+        self._framer.reset()
+        self.last_message = b""
+
+    @property
+    def buffer(self) -> bytes:
+        return self._framer.buffer.pending
 
     def connection_lost(self, exc):
         logger.error("The serial port was closed")
@@ -103,7 +103,7 @@ class SerialCommunication(ConnectionHandler):
         self.connected = False
 
     def make_protocol(self):
-        return SerialConnectionProtocol(self)
+        return GsmSerialProtocol(self)
 
     async def write(self, message, timeout=15):
         logger.debug(f"I->M: {message}")

--- a/tests/connection/prt3/test_framing.py
+++ b/tests/connection/prt3/test_framing.py
@@ -2,8 +2,7 @@
 
 import pytest
 
-from paradox.connections.framing import Frame
-from paradox.connections.prt3.framing import MAX_LINE_LENGTH, LineFramer
+from paradox.connections.framing import MAX_LINE_LENGTH, Frame, LineFramer
 
 
 @pytest.fixture

--- a/tests/connection/test_framing.py
+++ b/tests/connection/test_framing.py
@@ -181,7 +181,7 @@ def _ip_framer():
 
 
 def _line_framer():
-    from paradox.connections.prt3.framing import LineFramer
+    from paradox.connections.framing import LineFramer
 
     return LineFramer()
 

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -3,10 +3,11 @@ from unittest import mock
 
 import pytest
 
+from paradox.connections.framing import MAX_LINE_LENGTH
 from paradox.interfaces.text.gsm import (
+    GsmSerialProtocol,
     GSMTextInterface,
     SerialCommunication,
-    SerialConnectionProtocol,
 )
 
 
@@ -39,11 +40,11 @@ async def connected_serial_communication():
     return comm
 
 
-# Test SerialConnectionProtocol class
+# Test GsmSerialProtocol class
 @pytest.mark.asyncio
-async def test_serial_connection_protocol():
+async def test_gsm_serial_protocol():
     handler = mock.MagicMock()
-    protocol = SerialConnectionProtocol(handler)
+    protocol = GsmSerialProtocol(handler)
 
     transport = mock.MagicMock()
     protocol.connection_made(transport)
@@ -63,12 +64,9 @@ async def test_serial_connection_protocol():
 
 
 @pytest.mark.asyncio
-async def test_serial_connection_protocol_reassembles_split_frames():
-    # Characterization test: pins the existing framing contract so the buffer
-    # can later be swapped for a shared framer. Not a regression test -- the
-    # pre-refactor loop passed this too.
+async def test_gsm_serial_protocol_reassembles_split_frames():
     handler = mock.MagicMock()
-    protocol = SerialConnectionProtocol(handler)
+    protocol = GsmSerialProtocol(handler)
     protocol.connection_made(mock.MagicMock())
 
     protocol.data_received(b"par")
@@ -87,18 +85,72 @@ async def test_serial_connection_protocol_reassembles_split_frames():
 
 
 @pytest.mark.asyncio
-async def test_serial_connection_protocol_drops_echoed_message():
-    # Characterization test: documents that echo suppression requires an exact
-    # match against the last sent message. See the follow-up issue on GSM
-    # framing for the `\r`-only echo and sticky `last_message` shortcomings.
+async def test_gsm_serial_protocol_drops_echoed_message():
     handler = mock.MagicMock()
-    protocol = SerialConnectionProtocol(handler)
+    protocol = GsmSerialProtocol(handler)
     protocol.connection_made(mock.MagicMock())
 
     await protocol.send_message(b"AT")
     protocol.data_received(b"AT\r\nOK\r\n")
 
     handler.on_message.assert_called_once_with(b"OK")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_drops_cr_terminated_echo():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"AT\r\r\nOK\r\n")
+
+    handler.on_message.assert_called_once_with(b"OK")
+
+
+def test_gsm_serial_protocol_preserves_cr_on_non_echo_message():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b"MESSAGE\r\r\n")
+
+    handler.on_message.assert_called_once_with(b"MESSAGE\r")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_only_checks_first_frame_for_echo():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"OK\r\nAT\r\n")
+
+    assert handler.on_message.call_args_list == [mock.call(b"OK"), mock.call(b"AT")]
+
+
+def test_gsm_serial_protocol_continues_after_callback_error():
+    handler = mock.MagicMock()
+    handler.on_message.side_effect = [
+        UnicodeDecodeError("utf-8", b"\xff", 0, 1, "bad"),
+        None,
+    ]
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b"\xff\r\nOK\r\n")
+
+    assert handler.on_message.call_args_list == [mock.call(b"\xff"), mock.call(b"OK")]
+    assert protocol.buffer == b""
+
+
+def test_gsm_serial_protocol_discards_oversized_partial_frame():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b"x" * (MAX_LINE_LENGTH + 1))
+
+    handler.on_message.assert_not_called()
+    assert protocol.buffer == b""
 
 
 # Test SerialCommunication class


### PR DESCRIPTION
## Summary

- promote the generic `LineFramer` into the shared connections framing module and keep the PRT3 import compatible
- replace GSM's hand-rolled CRLF buffer with the bounded shared framer and rename the protocol to `GsmSerialProtocol`
- scope echo suppression to the first response line, handle CR-terminated echoes, and keep draining frames when a callback raises
- add regression coverage for split frames, echoes, sticky state, callback failures, and oversized partial frames

Closes #611.

## Validation

- 54 focused tests passed
- 1,606 full tests passed
- focused coverage passed on Python 3.9 and 3.12
- pre-commit passed
- strict Flake8 passed