### PR TITLE
refactor(gsm): move the modem transport into connections/gsm/

### DIFF
--- a/paradox/connections/gsm/__init__.py
+++ b/paradox/connections/gsm/__init__.py
@@ -1,0 +1,1 @@
+# GSM connection package — AT-command serial transport for a GSM modem.

--- a/paradox/connections/gsm/connection.py
+++ b/paradox/connections/gsm/connection.py
@@ -1,0 +1,138 @@
+"""GsmSerialConnection — serial transport for an AT-command GSM modem.
+
+Unlike the panel transports, this one is a request/response command channel:
+``send_command()`` writes a line and waits for the modem's reply. Unsolicited
+lines (``+CMT``, ``+CUSD``) arrive at any time, so the consumer switches
+between draining the queue during init and a push callback afterwards.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Callable, Optional
+
+import serial_asyncio
+
+from paradox.connections.connection import Connection
+from paradox.connections.gsm.protocol import GsmSerialProtocol
+
+logger = logging.getLogger("PAI").getChild(__name__)
+
+#: Seconds to wait for the serial port to open before giving up.
+DEFAULT_OPEN_TIMEOUT = 5
+
+#: Seconds to wait for the modem to answer a command.
+DEFAULT_COMMAND_TIMEOUT = 5
+
+
+class GsmSerialConnection(Connection):
+    """Serial transport for a GSM modem speaking AT commands.
+
+    Named apart from :class:`paradox.connections.serial.connection.SerialCommunication`,
+    which is the panel's binary serial transport: the two share a medium and
+    nothing else.
+    """
+
+    def __init__(self, port, baud=9600, timeout=DEFAULT_OPEN_TIMEOUT):
+        super().__init__()
+        self.port_path = port
+        self.baud = baud
+        self.open_timeout_seconds = timeout
+        self.connected_future = None
+        self.recv_callback = None
+        self.queue = asyncio.Queue()
+
+    def clear(self):
+        self.queue = asyncio.Queue()
+
+    def on_connection_loss(self):
+        logger.error("Connection was lost")
+        self.connected = False
+        # A drop after a successful connect finds the future already resolved.
+        if self.connected_future is not None and not self.connected_future.done():
+            self.connected_future.set_result(False)
+
+    def on_connection(self):
+        logger.info("Serial port open")
+        self.connected = True
+        if not self.connected_future.done():
+            self.connected_future.set_result(True)
+
+    def on_message(self, message: bytes):
+        """Route a modem line to the waiting caller or to the push callback.
+
+        Overrides :class:`~paradox.connections.connection.Connection`, whose
+        handler registry dispatches parsed panel messages. Modem lines are
+        plain bytes answering a specific command, so they queue instead.
+        """
+        logger.debug("M->I: %s", message)
+
+        if self.recv_callback is not None:
+            self.recv_callback(message)
+        else:
+            self.queue.put_nowait(message)
+
+    def set_recv_callback(self, callback: Optional[Callable[[bytes], bool]]):
+        self.recv_callback = callback
+
+    def open_timeout(self):
+        if self.connected_future.done():
+            return
+
+        logger.error("Serial Port Timeout")
+        self.connected = False
+        self.connected_future.set_result(False)
+
+    def make_protocol(self):
+        return GsmSerialProtocol(self)
+
+    def write(self, data: bytes):
+        """Unsupported: the modem channel is request/response.
+
+        ``Connection.write`` is a synchronous fire-and-forget that would leave
+        :meth:`GsmSerialProtocol.send_message`'s coroutine un-awaited.
+        """
+        raise NotImplementedError("Use send_command() for the modem channel")
+
+    async def send_command(self, message: bytes, timeout=DEFAULT_COMMAND_TIMEOUT):
+        """Send an AT command and wait for the modem's next line."""
+        if self._protocol is None:
+            return None
+
+        logger.debug("I->M: %s", message)
+        await self._protocol.send_message(message)
+        return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+
+    async def read(self, timeout=DEFAULT_COMMAND_TIMEOUT):
+        if self._protocol is None:
+            return None
+
+        return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+
+    async def connect(self) -> bool:
+        logger.info(f"Connecting to serial port {self.port_path}")
+
+        if not os.access(self.port_path, mode=os.R_OK | os.W_OK):
+            logger.error(f"{self.port_path} is not readable/writable.")
+            return False
+
+        self.connected_future = asyncio.get_running_loop().create_future()
+        open_timeout_handler = asyncio.get_running_loop().call_later(
+            self.open_timeout_seconds, self.open_timeout
+        )
+
+        try:
+            _, self._protocol = await serial_asyncio.create_serial_connection(
+                asyncio.get_running_loop(),
+                self.make_protocol,
+                self.port_path,
+                self.baud,
+            )
+
+            return await self.connected_future
+        except Exception:
+            logger.exception("Unable to connect to GSM modem")
+        finally:
+            open_timeout_handler.cancel()
+
+        return False

--- a/paradox/connections/gsm/protocol.py
+++ b/paradox/connections/gsm/protocol.py
@@ -1,0 +1,87 @@
+"""Framing and echo suppression for an AT-command GSM modem.
+
+Pure asyncio glue over :class:`~paradox.connections.framing.LineFramer`: no
+AT-command knowledge lives here beyond the echo of the last write.
+"""
+
+import logging
+
+from paradox.connections.framing import LineFramer
+from paradox.connections.handler import ConnectionHandler
+from paradox.connections.protocol_base import ConnectionProtocol
+
+logger = logging.getLogger("PAI").getChild(__name__)
+
+#: AT responses are short, but a text-mode ``+CMT`` line carries a whole SMS:
+#: 140 octets of UCS2 hex-encoded payload plus the header. 1 KiB leaves room
+#: for that and for verbose ``AT+CMEE=2`` error strings.
+MAX_LINE_LENGTH = 1024
+
+TERMINATOR = b"\r\n"
+
+
+class GsmSerialProtocol(ConnectionProtocol):
+    """CRLF line framing and modem echo suppression for an AT-command modem.
+
+    Named apart from
+    :class:`paradox.connections.serial.protocol.SerialConnectionProtocol`
+    because the two are not substitutable: that one's ``send_message`` is
+    synchronous, this one's is a coroutine.
+    """
+
+    def __init__(self, handler: ConnectionHandler):
+        super().__init__(handler)
+        self.last_message = b""
+        self._framer = LineFramer(
+            terminator=TERMINATOR,
+            max_line_length=MAX_LINE_LENGTH,
+            strip_terminator=True,
+        )
+
+    async def send_message(self, message):
+        self.last_message = message
+        self.transport.write(message + TERMINATOR)
+
+    def data_received(self, recv_data):
+        for frame in self._framer.feed(recv_data):
+            message = frame.data
+            logger.debug("M->P: %s", message)
+
+            if self._is_echo(message):
+                continue
+
+            try:
+                self.handler.on_message(message)
+            except Exception:
+                # A single unparseable line must not strand the frames behind
+                # it: they would sit in the buffer until the next byte arrives.
+                logger.exception("Error handling modem message")
+
+    def _is_echo(self, message: bytes) -> bool:
+        """True when ``message`` is the modem echoing back the last command.
+
+        Echo suppression is scoped to the first line after a write. Echo is
+        normally off (``connect()`` issues ``ATE0``), so an expectation that
+        outlived its response would eventually swallow an unrelated line that
+        happened to match the last command.
+
+        The comparison tolerates a trailing ``\\r`` because many V.25ter modems
+        echo the command terminated by a bare ``<CR>`` and only then send
+        ``<CR><LF>OK<CR><LF>``.
+        """
+        expected, self.last_message = self.last_message, b""
+        return bool(expected) and message.rstrip(b"\r") == expected.rstrip(b"\r")
+
+    def reset_framing(self) -> None:
+        self._framer.reset()
+        self.last_message = b""
+
+    @property
+    def buffer(self) -> bytes:
+        """Unconsumed bytes. Retained for tests and diagnostics."""
+        return self._framer.buffer.pending
+
+    def connection_lost(self, exc):
+        logger.error("The serial port was closed")
+        self.last_message = b""
+        super().connection_lost(exc)

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -1,15 +1,9 @@
 import asyncio
 import json
 import logging
-import os
-from typing import Callable, Optional
-
-import serial_asyncio
 
 from paradox.config import config as cfg
-from paradox.connections.connection import ConnectionProtocol
-from paradox.connections.framing import LineFramer
-from paradox.connections.handler import ConnectionHandler
+from paradox.connections.gsm.connection import GsmSerialConnection
 from paradox.event import EventLevel, Notification
 from paradox.interfaces.text.core import ConfiguredAbstractTextInterface
 from paradox.lib import ps
@@ -18,148 +12,6 @@ from paradox.lib import ps
 # Only exposes critical status changes and accepts commands
 
 logger = logging.getLogger("PAI").getChild(__name__)
-
-#: AT responses are short, but a text-mode ``+CMT`` line carries a whole SMS:
-#: 140 octets of UCS2 hex-encoded payload plus the header. 1 KiB leaves room
-#: for that and for verbose ``AT+CMEE=2`` error strings.
-MAX_LINE_LENGTH = 1024
-
-TERMINATOR = b"\r\n"
-
-
-class GsmSerialProtocol(ConnectionProtocol):
-    """CRLF line framing and modem echo suppression for an AT-command modem.
-
-    Named apart from
-    :class:`paradox.connections.serial.protocol.SerialConnectionProtocol`
-    because the two are not substitutable: that one's ``send_message`` is
-    synchronous, this one's is a coroutine.
-    """
-
-    def __init__(self, handler: ConnectionHandler):
-        super().__init__(handler)
-        self.last_message = b""
-        self._framer = LineFramer(
-            terminator=TERMINATOR,
-            max_line_length=MAX_LINE_LENGTH,
-            strip_terminator=True,
-        )
-
-    async def send_message(self, message):
-        self.last_message = message
-        self.transport.write(message + TERMINATOR)
-
-    def data_received(self, recv_data):
-        for frame in self._framer.feed(recv_data):
-            message = frame.data
-            logger.debug("M->P: %s", message)
-
-            if self._is_echo(message):
-                continue
-
-            try:
-                self.handler.on_message(message)
-            except Exception:
-                # A single unparseable line must not strand the frames behind
-                # it: they would sit in the buffer until the next byte arrives.
-                logger.exception("Error handling modem message")
-
-    def _is_echo(self, message: bytes) -> bool:
-        """True when ``message`` is the modem echoing back the last command.
-
-        Echo suppression is scoped to the first line after a write. Echo is
-        normally off (``connect()`` issues ``ATE0``), so an expectation that
-        outlived its response would eventually swallow an unrelated line that
-        happened to match the last command.
-
-        The comparison tolerates a trailing ``\\r`` because many V.25ter modems
-        echo the command terminated by a bare ``<CR>`` and only then send
-        ``<CR><LF>OK<CR><LF>``.
-        """
-        expected, self.last_message = self.last_message, b""
-        return bool(expected) and message.rstrip(b"\r") == expected.rstrip(b"\r")
-
-    def reset_framing(self) -> None:
-        self._framer.reset()
-        self.last_message = b""
-
-    @property
-    def buffer(self) -> bytes:
-        """Unconsumed bytes. Retained for tests and diagnostics."""
-        return self._framer.buffer.pending
-
-    def connection_lost(self, exc):
-        logger.error("The serial port was closed")
-        self.last_message = b""
-        super().connection_lost(exc)
-
-
-class SerialCommunication(ConnectionHandler):
-    def __init__(self, port, baud=9600, timeout=5):
-        self.port_path = port
-        self.baud = baud
-        self.connected_future = None
-        self.recv_callback = None
-        self.connected = False
-        self.connection = None
-        self.queue = asyncio.Queue()
-
-    def clear(self):
-        self.queue = asyncio.Queue()
-
-    def on_connection_loss(self):
-        logger.error("Connection was lost")
-        self.connected_future.set_result(False)
-        self.connected = False
-
-    def on_connection(self):
-        logger.info("Serial port open")
-        self.connected_future.set_result(True)
-        self.connected = True
-
-    def on_message(self, message: bytes):
-        logger.debug(f"M->I: {message}")
-
-        if self.recv_callback is not None:
-            self.recv_callback(message)  # Callback
-        else:
-            self.queue.put_nowait(message)
-
-    def set_recv_callback(self, callback: Optional[Callable[[str], bool]]):
-        self.recv_callback = callback
-
-    def open_timeout(self):
-        if self.connected_future.done():
-            return
-
-        logger.error("Serial Port Timeout")
-        self.connected_future.set_result(False)
-        self.connected = False
-
-    def make_protocol(self):
-        return GsmSerialProtocol(self)
-
-    async def write(self, message, timeout=15):
-        logger.debug(f"I->M: {message}")
-        if self.connection is not None:
-            await self.connection.send_message(message)
-            return await asyncio.wait_for(self.queue.get(), timeout=5)
-
-    async def read(self, timeout=5):
-        if self.connection is not None:
-            return await asyncio.wait_for(self.queue.get(), timeout=timeout)
-
-    async def connect(self):
-        logger.info(f"Connecting to serial port {self.port_path}")
-
-        self.connected_future = asyncio.get_running_loop().create_future()
-        asyncio.get_running_loop().call_later(5, self.open_timeout)
-
-        _, self.connection = await serial_asyncio.create_serial_connection(
-            asyncio.get_running_loop(), self.make_protocol, self.port_path, self.baud
-        )
-
-        return await self.connected_future
 
 
 class GSMTextInterface(ConfiguredAbstractTextInterface):
@@ -181,12 +33,21 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
     def stop(self):
         """Stops the GSM Interface"""
         super().stop()
-        logger.debug("GSM Stopped. TODO: Implement a proper stop")
+
+        if self.port is not None:
+            # stop() is synchronous, so the close can only be scheduled. The
+            # port is dropped either way: a half-closed port is still better
+            # than one held open for the life of the process.
+            port, self.port = self.port, None
+            self.modem_connected = False
+            self._loop.create_task(port.close())
+
+        logger.debug("GSM Stopped")
 
     async def write(self, message: str, expected: str = None) -> None:
         r = b""
         while r != expected:
-            r = await self.port.write(message)
+            r = await self.port.send_command(message)
             data = b""
 
             if r == b"ERROR":
@@ -198,24 +59,13 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
     async def connect(self):
         logger.info(f"Using {cfg.GSM_MODEM_PORT} at {cfg.GSM_MODEM_BAUDRATE} baud")
-        try:
-            if not os.path.exists(cfg.GSM_MODEM_PORT):
-                logger.error(f"Modem port ({cfg.GSM_MODEM_PORT}) not found")
-                return False
-
-            self.port = SerialCommunication(
-                cfg.GSM_MODEM_PORT, cfg.GSM_MODEM_BAUDRATE, 5
-            )
-
-        except Exception:
-            logger.exception(f"Could not open port {cfg.GSM_MODEM_PORT} for GSM modem")
-            return False
+        self.port = GsmSerialConnection(cfg.GSM_MODEM_PORT, cfg.GSM_MODEM_BAUDRATE, 5)
 
         self.port.set_recv_callback(None)
         result = await self.port.connect()
 
         if not result:
-            logger.exception("Could not connect to GSM modem")
+            logger.error("Could not connect to GSM modem")
             return False
 
         try:
@@ -310,7 +160,7 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             data = b'AT+CMGS="%b"\x0d%b\x1a' % (dst.encode(), message.encode())
 
             try:
-                result = await self.port.write(data)
+                result = await self.port.send_command(data)
                 logger.debug(f"SMS result: {result}")
             except Exception:
                 logger.exception("ERROR sending SMS")

--- a/tests/connection/gsm/test_connection.py
+++ b/tests/connection/gsm/test_connection.py
@@ -1,0 +1,132 @@
+"""Tests for the GSM modem serial transport."""
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from paradox.connections.gsm.connection import GsmSerialConnection
+
+
+@pytest.fixture
+async def connected_gsm_connection():
+    comm = GsmSerialConnection("test_port", 9600, 5)
+
+    assert comm.queue.empty()
+
+    async def mocked_create_serial_connection(loop, protocol_factory, *args, **kwargs):
+        transport = mock.Mock()
+        protocol = comm.make_protocol()
+        asyncio.get_event_loop().call_soon(protocol.connection_made, transport)
+        return (transport, protocol)
+
+    with mock.patch("os.access", return_value=True), mock.patch(
+        "serial_asyncio.create_serial_connection",
+        new_callable=mock.AsyncMock,
+        side_effect=mocked_create_serial_connection,
+    ):
+        asyncio.get_event_loop().call_soon(comm.on_connection)
+        result = await comm.connect()
+        assert result
+
+    assert comm.connected
+
+    return comm
+
+
+@pytest.mark.asyncio
+async def test_send_command_returns_the_next_modem_line(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    asyncio.get_event_loop().call_soon(comm.on_message, b"OK")
+    assert await comm.send_command(b"AT") == b"OK"
+
+
+@pytest.mark.asyncio
+async def test_read_drains_the_queue(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    asyncio.get_event_loop().call_soon(comm.on_message, b"read_message")
+    assert await comm.read() == b"read_message"
+    assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_recv_callback_takes_precedence_over_the_queue(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    callback = mock.MagicMock()
+    comm.set_recv_callback(callback)
+    comm.on_message(b"+CMT: unsolicited")
+
+    callback.assert_called_once_with(b"+CMT: unsolicited")
+    assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_send_command_honours_its_timeout(connected_gsm_connection):
+    """The timeout argument used to be accepted and then ignored.
+
+    The old code hardcoded ``wait_for(..., timeout=5)``, so this raised too,
+    just five seconds later. The elapsed check is what pins the fix.
+    """
+    comm = connected_gsm_connection
+
+    loop = asyncio.get_event_loop()
+    started = loop.time()
+    with pytest.raises(asyncio.TimeoutError):
+        await comm.send_command(b"AT", timeout=0.01)
+
+    assert loop.time() - started < 1
+
+
+@pytest.mark.asyncio
+async def test_write_is_rejected(connected_gsm_connection):
+    """Connection.write() would leave send_message's coroutine un-awaited."""
+    with pytest.raises(NotImplementedError):
+        connected_gsm_connection.write(b"AT")
+
+
+@pytest.mark.asyncio
+async def test_connection_loss_after_connect_does_not_raise(connected_gsm_connection):
+    """The connected_future is already resolved by then."""
+    comm = connected_gsm_connection
+
+    comm.on_connection_loss()
+
+    assert not comm.connected
+
+
+@pytest.mark.asyncio
+async def test_connect_fails_when_the_port_is_not_accessible():
+    comm = GsmSerialConnection("test_port", 9600, 5)
+
+    with mock.patch("os.access", return_value=False):
+        assert await comm.connect() is False
+
+
+@pytest.mark.asyncio
+async def test_connect_gives_up_after_the_open_timeout():
+    comm = GsmSerialConnection("test_port", 9600, 0.01)
+
+    async def never_connects(loop, protocol_factory, *args, **kwargs):
+        return (mock.Mock(), comm.make_protocol())
+
+    with mock.patch("os.access", return_value=True), mock.patch(
+        "serial_asyncio.create_serial_connection",
+        new_callable=mock.AsyncMock,
+        side_effect=never_connects,
+    ):
+        assert await comm.connect() is False
+
+    assert not comm.connected
+
+
+@pytest.mark.asyncio
+async def test_clear_replaces_the_queue(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    comm.on_message(b"stale")
+    comm.clear()
+
+    assert comm.queue.empty()

--- a/tests/connection/gsm/test_protocol.py
+++ b/tests/connection/gsm/test_protocol.py
@@ -1,0 +1,149 @@
+"""Tests for the GSM modem line protocol."""
+
+from unittest import mock
+
+import pytest
+
+from paradox.connections.gsm.protocol import MAX_LINE_LENGTH, GsmSerialProtocol
+
+
+# Test GsmSerialProtocol class
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    transport = mock.MagicMock()
+    protocol.connection_made(transport)
+    handler.on_connection.assert_called_once()
+
+    message = b"test_message"
+    await protocol.send_message(message)
+    transport.write.assert_called_once_with(message + b"\r\n")
+
+    recv_data = b"test_data\r\n"
+    protocol.data_received(recv_data)
+    handler.on_message.assert_called_once_with(b"test_data")
+
+    exc = Exception("test_exception")
+    protocol.connection_lost(exc)
+    handler.on_connection_loss.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_reassembles_split_frames():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    protocol.data_received(b"par")
+    handler.on_message.assert_not_called()
+
+    protocol.data_received(b"tial\r\n\r\nOK\r\ntrail")
+
+    assert handler.on_message.call_args_list == [
+        mock.call(b"partial"),
+        mock.call(b"OK"),
+    ]
+    assert protocol.buffer == b"trail"
+
+    protocol.reset_framing()
+    assert protocol.buffer == b""
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_drops_echoed_message():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"AT\r\nOK\r\n")
+
+    handler.on_message.assert_called_once_with(b"OK")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_drops_cr_terminated_echo():
+    """Many V.25ter modems echo the command terminated by a bare CR."""
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"AT\r\r\nOK\r\n")
+
+    handler.on_message.assert_called_once_with(b"OK")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_echo_expectation_is_not_sticky():
+    """Echo is off after ATE0, so the expectation must die with the response."""
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT+CUSD=1")
+    protocol.data_received(b"OK\r\n")
+    protocol.data_received(b"AT+CUSD=1\r\n")
+
+    assert handler.on_message.call_args_list == [
+        mock.call(b"OK"),
+        mock.call(b"AT+CUSD=1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_only_checks_the_first_frame_for_echo():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"OK\r\nAT\r\n")
+
+    assert handler.on_message.call_args_list == [mock.call(b"OK"), mock.call(b"AT")]
+
+
+def test_gsm_serial_protocol_keeps_draining_after_a_callback_raises():
+    handler = mock.MagicMock()
+    handler.on_message.side_effect = [ValueError("bad line"), None]
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b"\xff\r\nOK\r\n")
+
+    assert handler.on_message.call_args_list == [mock.call(b"\xff"), mock.call(b"OK")]
+    assert protocol.buffer == b""
+
+
+def test_gsm_serial_protocol_discards_an_oversized_partial_frame():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b"x" * (MAX_LINE_LENGTH + 1))
+
+    handler.on_message.assert_not_called()
+    assert protocol.buffer == b""
+
+
+def test_gsm_serial_protocol_keeps_a_whitespace_only_line():
+    """An SMS body of a single space is data, not framing noise."""
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b" \r\n")
+
+    handler.on_message.assert_called_once_with(b" ")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_reset_framing_clears_echo_expectation():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.reset_framing()
+    protocol.data_received(b"AT\r\n")
+
+    handler.on_message.assert_called_once_with(b"AT")

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -3,22 +3,13 @@ from unittest import mock
 
 import pytest
 
-from paradox.interfaces.text.gsm import (
-    MAX_LINE_LENGTH,
-    GsmSerialProtocol,
-    GSMTextInterface,
-    SerialCommunication,
-)
+from paradox.connections.gsm.connection import GsmSerialConnection
+from paradox.interfaces.text.gsm import GSMTextInterface
 
 
 @pytest.fixture
-async def connected_serial_communication():
-    port = "test_port"
-    baud = 9600
-    timeout = 5
-    comm = SerialCommunication(port, baud, timeout)
-
-    assert comm.queue.empty()
+async def connected_gsm_connection():
+    comm = GsmSerialConnection("test_port", 9600, 5)
 
     async def mocked_create_serial_connection(loop, protocol_factory, *args, **kwargs):
         transport = mock.Mock()
@@ -26,189 +17,20 @@ async def connected_serial_communication():
         asyncio.get_event_loop().call_soon(protocol.connection_made, transport)
         return (transport, protocol)
 
-    with mock.patch(
+    with mock.patch("os.access", return_value=True), mock.patch(
         "serial_asyncio.create_serial_connection",
         new_callable=mock.AsyncMock,
         side_effect=mocked_create_serial_connection,
     ):
         asyncio.get_event_loop().call_soon(comm.on_connection)
-        result = await comm.connect()
-        assert result
-
-    assert comm.connected
+        assert await comm.connect()
 
     return comm
 
 
-# Test GsmSerialProtocol class
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-
-    transport = mock.MagicMock()
-    protocol.connection_made(transport)
-    handler.on_connection.assert_called_once()
-
-    message = b"test_message"
-    await protocol.send_message(message)
-    transport.write.assert_called_once_with(message + b"\r\n")
-
-    recv_data = b"test_data\r\n"
-    protocol.data_received(recv_data)
-    handler.on_message.assert_called_once_with(b"test_data")
-
-    exc = Exception("test_exception")
-    protocol.connection_lost(exc)
-    handler.on_connection_loss.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_reassembles_split_frames():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    protocol.data_received(b"par")
-    handler.on_message.assert_not_called()
-
-    protocol.data_received(b"tial\r\n\r\nOK\r\ntrail")
-
-    assert handler.on_message.call_args_list == [
-        mock.call(b"partial"),
-        mock.call(b"OK"),
-    ]
-    assert protocol.buffer == b"trail"
-
-    protocol.reset_framing()
-    assert protocol.buffer == b""
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_drops_echoed_message():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.data_received(b"AT\r\nOK\r\n")
-
-    handler.on_message.assert_called_once_with(b"OK")
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_drops_cr_terminated_echo():
-    """Many V.25ter modems echo the command terminated by a bare CR."""
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.data_received(b"AT\r\r\nOK\r\n")
-
-    handler.on_message.assert_called_once_with(b"OK")
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_echo_expectation_is_not_sticky():
-    """Echo is off after ATE0, so the expectation must die with the response."""
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT+CUSD=1")
-    protocol.data_received(b"OK\r\n")
-    protocol.data_received(b"AT+CUSD=1\r\n")
-
-    assert handler.on_message.call_args_list == [
-        mock.call(b"OK"),
-        mock.call(b"AT+CUSD=1"),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_only_checks_the_first_frame_for_echo():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.data_received(b"OK\r\nAT\r\n")
-
-    assert handler.on_message.call_args_list == [mock.call(b"OK"), mock.call(b"AT")]
-
-
-def test_gsm_serial_protocol_keeps_draining_after_a_callback_raises():
-    handler = mock.MagicMock()
-    handler.on_message.side_effect = [ValueError("bad line"), None]
-    protocol = GsmSerialProtocol(handler)
-
-    protocol.data_received(b"\xff\r\nOK\r\n")
-
-    assert handler.on_message.call_args_list == [mock.call(b"\xff"), mock.call(b"OK")]
-    assert protocol.buffer == b""
-
-
-def test_gsm_serial_protocol_discards_an_oversized_partial_frame():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-
-    protocol.data_received(b"x" * (MAX_LINE_LENGTH + 1))
-
-    handler.on_message.assert_not_called()
-    assert protocol.buffer == b""
-
-
-def test_gsm_serial_protocol_keeps_a_whitespace_only_line():
-    """An SMS body of a single space is data, not framing noise."""
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-
-    protocol.data_received(b" \r\n")
-
-    handler.on_message.assert_called_once_with(b" ")
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_reset_framing_clears_echo_expectation():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.reset_framing()
-    protocol.data_received(b"AT\r\n")
-
-    handler.on_message.assert_called_once_with(b"AT")
-
-
-# Test SerialCommunication class
-@pytest.mark.asyncio
-async def test_serial_communication(connected_serial_communication):
-    comm = connected_serial_communication
-
-    write_message = b"write_message"
-    write_response_message = b"write_response_message"
-    read_message = b"read_message"
-
-    asyncio.get_event_loop().call_soon(comm.on_message, write_response_message)
-    result = await comm.write(write_message)
-    assert result == write_response_message
-
-    asyncio.get_event_loop().call_soon(comm.on_message, read_message)
-    await comm.read()
-    assert comm.queue.empty()
-
-    callback = mock.MagicMock()
-    comm.set_recv_callback(callback)
-    assert comm.recv_callback == callback
-    comm.on_message(read_message)
-    callback.assert_called_once_with(read_message)
-
-
 # Test GSMTextInterface class
 @pytest.mark.asyncio
-async def test_gsm_text_interface(connected_serial_communication):
+async def test_gsm_text_interface(connected_gsm_connection):
     alarm = mock.MagicMock()
     event = asyncio.Event()
 
@@ -220,7 +42,7 @@ async def test_gsm_text_interface(connected_serial_communication):
         return True
 
     interface = GSMTextInterface(alarm)
-    interface.port = connected_serial_communication
+    interface.port = connected_gsm_connection
     interface.modem_connected = True
 
     data = b"+CMT: test_data"
@@ -262,3 +84,21 @@ async def test_gsm_text_interface_survives_a_malformed_cusd():
     interface = GSMTextInterface(mock.MagicMock())
 
     assert interface.data_received(b"+CUSD: not-json")
+
+
+@pytest.mark.asyncio
+async def test_gsm_text_interface_stop_closes_the_port(connected_gsm_connection):
+    """stop() used to be a no-op, leaking the serial port for the process."""
+    interface = GSMTextInterface(mock.MagicMock())
+    interface.port = connected_gsm_connection
+    interface.modem_connected = True
+
+    with mock.patch.object(
+        connected_gsm_connection, "close", new_callable=mock.AsyncMock
+    ) as close:
+        interface.stop()
+        await asyncio.sleep(0)
+
+    close.assert_awaited_once()
+    assert interface.port is None
+    assert not interface.modem_connected


### PR DESCRIPTION
Closes item 8 of #611 — the one item PR #613 deliberately left out.

> **Stacked on #613.** Base is `fix/611-gsm-line-framing`, so the diff shown here is only this refactor. I'll retarget to `dev` once #613 merges.

## Why

`SerialCommunication` sat in `paradox/interfaces/text/gsm.py` and was a parallel hand-rolled reimplementation of the `Connection` abstraction — its own queue, `connected_future`, `open_timeout` and `make_protocol`. It also shared its name with `paradox/connections/serial/connection.py`'s panel transport: two unrelated classes, one name, exactly the non-substitutable collision item 7 fixed for the protocol classes.

## Changes

**New `paradox/connections/gsm/`**, mirroring `ip/`, `serial/` and `prt3/`:

- `protocol.py` — `GsmSerialProtocol`, moved unchanged from the interface module.
- `connection.py` — `GsmSerialConnection`, was `SerialCommunication`.

**Convergence on `Connection`** is deliberately partial. `GsmSerialConnection` inherits the lifecycle — the protocol-aware `connected` property (it was a bool that could go stale against a dead transport), `_protocol` plumbing, and `close()`, which the GSM transport simply did not have. `on_message` stays overridden to keep the queue and `recv_callback` dispatch: modem lines are plain bytes answering a specific AT command, and forcing them through `Connection`'s parsed-message handler registry would be a risky rewrite of the modem init sequence for no benefit.

**`send_command()`** is the renamed request/response method. Leaving it as `write()` would have collided with `Connection.write()` — synchronous, fire-and-forget — and silently left `GsmSerialProtocol.send_message`'s coroutine un-awaited. `Connection.write()` is overridden to raise `NotImplementedError` rather than leave that trap armed.

**`GSMTextInterface`** is now AT orchestration and SMS parsing only, down from 300 to ~180 lines. `stop()` closes the port instead of logging `TODO: Implement a proper stop`; since `stop()` is synchronous the close is scheduled, and the port reference is dropped either way.

## Bugs fixed in the moved code

All of these are things `connections/serial/connection.py` already gets right:

- `on_connection` / `on_connection_loss` called `connected_future.set_result()` unguarded, so a modem drop **after** a successful connect raised `InvalidStateError`.
- The `call_later(5, self.open_timeout)` handle was never cancelled, and the constructor's `timeout` argument was accepted and then ignored in favour of a hardcoded `5`.
- `write(self, message, timeout=15)` ignored its own `timeout` and hardcoded `wait_for(..., timeout=5)`.
- The port check was `os.path.exists`, which misses the far more common permission failure that `os.access(R_OK|W_OK)` catches.
- `connect()` reported failure with `logger.exception` outside any `except` block, emitting a bogus `NoneType: None` traceback.

## Tests

Split to mirror the package layout: `tests/connection/gsm/test_protocol.py` and `tests/connection/gsm/test_connection.py`, leaving `tests/interfaces/test_gsm.py` for the interface. New coverage for the connection lifecycle, the ignored timeouts, the rejected `write()`, and `stop()` closing the port.

## Out of scope

`GSMTextInterface.write`'s retry loop — the dead `data` accumulator and the doubled `while r != expected` — is untouched. It is confusing and probably wrong, but it is a separate concern from where the transport lives.

## Validation

- 1630 tests pass
- pre-commit passes
- Python 3.8 syntax verified
