### PR TITLE
fix(gsm): follow-up review fixes + restore the connections/gsm package

### DIFF
--- a/paradox/connections/framing.py
+++ b/paradox/connections/framing.py
@@ -190,15 +190,19 @@ class LineFramer(Framer):
     ``strip_terminator``
         Drop the terminator from the emitted frame. Off by default, so the
         consumer can verify framing.
-    ``drop_blank_lines``
-        Skip lines whose payload has no printable content. Off by default,
-        which skips only genuinely empty payloads: a bare terminator carries
-        no message, but a whitespace-only line may still be data.
+    ``drop_whitespace_lines``
+        Also skip lines whose payload is only whitespace. Empty payloads are
+        always skipped -- a bare terminator carries no message -- but a
+        whitespace-only line may still be data, so discarding it is opt-in.
 
     ``max_line_length``
         Discard the buffer once it exceeds this without a terminator. The
         default is a fallback only: a bound that suits one transport's line
         lengths silently truncates another's, so pass your own.
+
+    A discarded overrun is followed by a resynchronisation: bytes are dropped
+    up to and including the next terminator, so the tail of the line that
+    overran is not emitted as if it were a whole line of its own.
     """
 
     def __init__(
@@ -206,7 +210,7 @@ class LineFramer(Framer):
         terminator: bytes = b"\r",
         max_line_length: int = DEFAULT_MAX_LINE_LENGTH,
         strip_terminator: bool = False,
-        drop_blank_lines: bool = False,
+        drop_whitespace_lines: bool = False,
     ) -> None:
         super().__init__()
         if not terminator:
@@ -214,7 +218,12 @@ class LineFramer(Framer):
         self._terminator = terminator
         self._max_line_length = max_line_length
         self._strip_terminator = strip_terminator
-        self._drop_blank_lines = drop_blank_lines
+        self._drop_whitespace_lines = drop_whitespace_lines
+        self._resyncing = False
+
+    def reset(self) -> None:
+        super().reset()
+        self._resyncing = False
 
     def _next_frame(self) -> Optional[Frame]:
         """Return the next line, or ``None`` to wait for more data."""
@@ -231,14 +240,20 @@ class LineFramer(Framer):
                         self._max_line_length,
                     )
                     self.buffer.clear()
+                    self._resyncing = True
                 return None
 
             line = self.buffer.take(index + len(self._terminator))
+
+            if self._resyncing:
+                # The tail of the overrun line, not a line in its own right.
+                self._resyncing = False
+                continue
+
             payload = line[: -len(self._terminator)]
-            if self._drop_blank_lines:
-                if not payload.strip():
-                    continue
-            elif not payload:
+            if not payload:
+                continue
+            if self._drop_whitespace_lines and not payload.strip():
                 continue
 
             return Frame(payload if self._strip_terminator else line)

--- a/paradox/connections/framing.py
+++ b/paradox/connections/framing.py
@@ -190,7 +190,7 @@ class LineFramer(Framer):
     ``strip_terminator``
         Drop the terminator from the emitted frame. Off by default, so the
         consumer can verify framing.
-    ``drop_whitespace_lines``
+    ``drop_blank_lines``
         Also skip lines whose payload is only whitespace. Empty payloads are
         always skipped -- a bare terminator carries no message -- but a
         whitespace-only line may still be data, so discarding it is opt-in.
@@ -210,7 +210,7 @@ class LineFramer(Framer):
         terminator: bytes = b"\r",
         max_line_length: int = DEFAULT_MAX_LINE_LENGTH,
         strip_terminator: bool = False,
-        drop_whitespace_lines: bool = False,
+        drop_blank_lines: bool = False,
     ) -> None:
         super().__init__()
         if not terminator:
@@ -218,7 +218,7 @@ class LineFramer(Framer):
         self._terminator = terminator
         self._max_line_length = max_line_length
         self._strip_terminator = strip_terminator
-        self._drop_whitespace_lines = drop_whitespace_lines
+        self._drop_blank_lines = drop_blank_lines
         self._resyncing = False
 
     def reset(self) -> None:
@@ -253,7 +253,7 @@ class LineFramer(Framer):
             payload = line[: -len(self._terminator)]
             if not payload:
                 continue
-            if self._drop_whitespace_lines and not payload.strip():
+            if self._drop_blank_lines and not payload.strip():
                 continue
 
             return Frame(payload if self._strip_terminator else line)

--- a/paradox/connections/gsm/__init__.py
+++ b/paradox/connections/gsm/__init__.py
@@ -1,0 +1,1 @@
+# GSM connection package — AT-command serial transport for a GSM modem.

--- a/paradox/connections/gsm/connection.py
+++ b/paradox/connections/gsm/connection.py
@@ -43,7 +43,13 @@ class GsmSerialConnection(Connection):
         self.queue = asyncio.Queue()
 
     def clear(self):
-        self.queue = asyncio.Queue()
+        """Drop any unread modem output.
+
+        Drains in place rather than replacing the queue: a coroutine already
+        blocked in :meth:`read` would otherwise wait on the old object forever.
+        """
+        while not self.queue.empty():
+            self.queue.get_nowait()
 
     def on_connection_loss(self):
         logger.error("Connection was lost")
@@ -101,16 +107,30 @@ class GsmSerialConnection(Connection):
 
         Set ``expect_prompt`` when the command is answered by an unterminated
         ``"> "`` entry prompt rather than by a line, as ``AT+CMGS`` is.
+
+        Callers must serialise their own exchanges: the modem answers one
+        command at a time, and the reply queue cannot tell two callers apart.
         """
+        if self._protocol is None:
+            raise ConnectionError("Not connected")
+
+        # Anything already queued predates this command, so it cannot be its
+        # reply. Most often it is the late answer to one that timed out.
+        self.clear()
+
         logger.debug("I->M: %s", message)
 
         if expect_prompt:
-            if self._protocol is None:
-                raise ConnectionError("Not connected")
             self._protocol.expect_prompt()
 
-        self.write(message)
-        return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+        try:
+            self.write(message)
+            return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+        finally:
+            if expect_prompt and self._protocol is not None:
+                # An expectation that outlived its command would prime the
+                # next unterminated line to be read as a prompt.
+                self._protocol.disarm_prompt()
 
     def write_raw(self, message: bytes) -> None:
         """Write bytes with no line terminator, for an SMS body."""

--- a/paradox/connections/gsm/connection.py
+++ b/paradox/connections/gsm/connection.py
@@ -1,9 +1,9 @@
 """GsmSerialConnection — serial transport for an AT-command GSM modem.
 
 Unlike the panel transports, this one is a request/response command channel:
-``send_command()`` writes a line and waits for the modem's reply. Unsolicited
-lines (``+CMT``, ``+CUSD``) arrive at any time, so the consumer switches
-between draining the queue during init and a push callback afterwards.
+a caller writes a line and waits for the modem's reply. Unsolicited lines
+(``+CMT``, ``+CUSD``) arrive at any time, so the consumer switches between
+draining the queue during init and a push callback afterwards.
 """
 
 import asyncio
@@ -74,7 +74,8 @@ class GsmSerialConnection(Connection):
         The callback returns whether it consumed the line. Unsolicited results
         (``+CMT``, ``+CUSD``) belong to it; anything it declines is a reply to
         a command in flight and goes to the queue. Routing *everything* to the
-        callback would starve :meth:`send_command` for the life of the process.
+        callback would starve any caller waiting on a reply for the life of
+        the process.
         """
         logger.debug("M->I: %s", message)
 
@@ -97,54 +98,36 @@ class GsmSerialConnection(Connection):
     def make_protocol(self):
         return GsmSerialProtocol(self)
 
-    async def send_command(
-        self,
-        message: bytes,
-        timeout=DEFAULT_COMMAND_TIMEOUT,
-        expect_prompt: bool = False,
-    ):
-        """Send an AT command and wait for the modem's next line.
-
-        Set ``expect_prompt`` when the command is answered by an unterminated
-        ``"> "`` entry prompt rather than by a line, as ``AT+CMGS`` is.
-
-        Callers must serialise their own exchanges: the modem answers one
-        command at a time, and the reply queue cannot tell two callers apart.
-        """
-        if self._protocol is None:
-            raise ConnectionError("Not connected")
-
-        # Anything already queued predates this command, so it cannot be its
-        # reply. Most often it is the late answer to one that timed out.
-        self.clear()
-
-        logger.debug("I->M: %s", message)
-
-        if expect_prompt:
-            self._protocol.expect_prompt()
-
-        try:
-            self.write(message)
-            return await asyncio.wait_for(self.queue.get(), timeout=timeout)
-        finally:
-            if expect_prompt and self._protocol is not None:
-                # An expectation that outlived its command would prime the
-                # next unterminated line to be read as a prompt.
-                self._protocol.disarm_prompt()
-
     def write_raw(self, message: bytes) -> None:
         """Write bytes with no line terminator, for an SMS body."""
-        if not self.connected or self._protocol is None:
+        if self._protocol is None:
             raise ConnectionError("Not connected")
 
         logger.debug("I->M: %s (raw)", message)
         self._protocol.send_raw(message)
 
-    async def read(self, timeout=DEFAULT_COMMAND_TIMEOUT):
+    async def read(self, timeout=DEFAULT_COMMAND_TIMEOUT, expect_prompt: bool = False):
+        """Wait for the modem's next line.
+
+        Set ``expect_prompt`` when the reply is the unterminated ``"> "`` SMS
+        entry prompt rather than a line, as it is after ``AT+CMGS``. The
+        expectation is dropped again on the way out: one that outlived its
+        command would prime the next unterminated line to be read as a prompt.
+
+        Callers must serialise their own exchanges -- the modem answers one
+        command at a time, and the reply queue cannot tell two callers apart.
+        """
         if self._protocol is None:
             return None
 
-        return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+        if expect_prompt:
+            self._protocol.expect_prompt()
+
+        try:
+            return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+        finally:
+            if expect_prompt and self._protocol is not None:
+                self._protocol.disarm_prompt()
 
     async def connect(self) -> bool:
         logger.info(f"Connecting to serial port {self.port_path}")

--- a/paradox/connections/gsm/connection.py
+++ b/paradox/connections/gsm/connection.py
@@ -18,10 +18,7 @@ from paradox.connections.gsm.protocol import GsmSerialProtocol
 
 logger = logging.getLogger("PAI").getChild(__name__)
 
-#: Seconds to wait for the serial port to open before giving up.
 DEFAULT_OPEN_TIMEOUT = 5
-
-#: Seconds to wait for the modem to answer a command.
 DEFAULT_COMMAND_TIMEOUT = 5
 
 
@@ -29,8 +26,7 @@ class GsmSerialConnection(Connection):
     """Serial transport for a GSM modem speaking AT commands.
 
     Named apart from :class:`paradox.connections.serial.connection.SerialCommunication`,
-    which is the panel's binary serial transport: the two share a medium and
-    nothing else.
+    which is the panel's binary serial transport.
     """
 
     def __init__(self, port, baud=9600, timeout=DEFAULT_OPEN_TIMEOUT):
@@ -66,10 +62,6 @@ class GsmSerialConnection(Connection):
 
     def on_message(self, message: bytes):
         """Route a modem line to the push callback, or to the waiting caller.
-
-        Overrides :class:`~paradox.connections.connection.Connection`, whose
-        handler registry dispatches parsed panel messages. Modem lines are
-        plain bytes, so they queue instead.
 
         The callback returns whether it consumed the line. Unsolicited results
         (``+CMT``, ``+CUSD``) belong to it; anything it declines is a reply to

--- a/paradox/connections/gsm/connection.py
+++ b/paradox/connections/gsm/connection.py
@@ -1,0 +1,138 @@
+"""GsmSerialConnection — serial transport for an AT-command GSM modem.
+
+Unlike the panel transports, this one is a request/response command channel:
+``send_command()`` writes a line and waits for the modem's reply. Unsolicited
+lines (``+CMT``, ``+CUSD``) arrive at any time, so the consumer switches
+between draining the queue during init and a push callback afterwards.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Callable, Optional
+
+import serial_asyncio
+
+from paradox.connections.connection import Connection
+from paradox.connections.gsm.protocol import GsmSerialProtocol
+
+logger = logging.getLogger("PAI").getChild(__name__)
+
+#: Seconds to wait for the serial port to open before giving up.
+DEFAULT_OPEN_TIMEOUT = 5
+
+#: Seconds to wait for the modem to answer a command.
+DEFAULT_COMMAND_TIMEOUT = 5
+
+
+class GsmSerialConnection(Connection):
+    """Serial transport for a GSM modem speaking AT commands.
+
+    Named apart from :class:`paradox.connections.serial.connection.SerialCommunication`,
+    which is the panel's binary serial transport: the two share a medium and
+    nothing else.
+    """
+
+    def __init__(self, port, baud=9600, timeout=DEFAULT_OPEN_TIMEOUT):
+        super().__init__()
+        self.port_path = port
+        self.baud = baud
+        self.open_timeout_seconds = timeout
+        self.connected_future = None
+        self.recv_callback = None
+        self.queue = asyncio.Queue()
+
+    def clear(self):
+        self.queue = asyncio.Queue()
+
+    def on_connection_loss(self):
+        logger.error("Connection was lost")
+        self.connected = False
+        # A drop after a successful connect finds the future already resolved.
+        if self.connected_future is not None and not self.connected_future.done():
+            self.connected_future.set_result(False)
+
+    def on_connection(self):
+        logger.info("Serial port open")
+        self.connected = True
+        if not self.connected_future.done():
+            self.connected_future.set_result(True)
+
+    def on_message(self, message: bytes):
+        """Route a modem line to the waiting caller or to the push callback.
+
+        Overrides :class:`~paradox.connections.connection.Connection`, whose
+        handler registry dispatches parsed panel messages. Modem lines are
+        plain bytes answering a specific command, so they queue instead.
+        """
+        logger.debug("M->I: %s", message)
+
+        if self.recv_callback is not None:
+            self.recv_callback(message)
+        else:
+            self.queue.put_nowait(message)
+
+    def set_recv_callback(self, callback: Optional[Callable[[bytes], bool]]):
+        self.recv_callback = callback
+
+    def open_timeout(self):
+        if self.connected_future.done():
+            return
+
+        logger.error("Serial Port Timeout")
+        self.connected = False
+        self.connected_future.set_result(False)
+
+    def make_protocol(self):
+        return GsmSerialProtocol(self)
+
+    def write(self, data: bytes):
+        """Unsupported: the modem channel is request/response.
+
+        ``Connection.write`` is a synchronous fire-and-forget that would leave
+        :meth:`GsmSerialProtocol.send_message`'s coroutine un-awaited.
+        """
+        raise NotImplementedError("Use send_command() for the modem channel")
+
+    async def send_command(self, message: bytes, timeout=DEFAULT_COMMAND_TIMEOUT):
+        """Send an AT command and wait for the modem's next line."""
+        if self._protocol is None:
+            return None
+
+        logger.debug("I->M: %s", message)
+        await self._protocol.send_message(message)
+        return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+
+    async def read(self, timeout=DEFAULT_COMMAND_TIMEOUT):
+        if self._protocol is None:
+            return None
+
+        return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+
+    async def connect(self) -> bool:
+        logger.info(f"Connecting to serial port {self.port_path}")
+
+        if not os.access(self.port_path, mode=os.R_OK | os.W_OK):
+            logger.error(f"{self.port_path} is not readable/writable.")
+            return False
+
+        self.connected_future = asyncio.get_running_loop().create_future()
+        open_timeout_handler = asyncio.get_running_loop().call_later(
+            self.open_timeout_seconds, self.open_timeout
+        )
+
+        try:
+            _, self._protocol = await serial_asyncio.create_serial_connection(
+                asyncio.get_running_loop(),
+                self.make_protocol,
+                self.port_path,
+                self.baud,
+            )
+
+            return await self.connected_future
+        except Exception:
+            logger.exception("Unable to connect to GSM modem")
+        finally:
+            open_timeout_handler.cancel()
+
+        return False

--- a/paradox/connections/gsm/connection.py
+++ b/paradox/connections/gsm/connection.py
@@ -59,18 +59,23 @@ class GsmSerialConnection(Connection):
             self.connected_future.set_result(True)
 
     def on_message(self, message: bytes):
-        """Route a modem line to the waiting caller or to the push callback.
+        """Route a modem line to the push callback, or to the waiting caller.
 
         Overrides :class:`~paradox.connections.connection.Connection`, whose
         handler registry dispatches parsed panel messages. Modem lines are
-        plain bytes answering a specific command, so they queue instead.
+        plain bytes, so they queue instead.
+
+        The callback returns whether it consumed the line. Unsolicited results
+        (``+CMT``, ``+CUSD``) belong to it; anything it declines is a reply to
+        a command in flight and goes to the queue. Routing *everything* to the
+        callback would starve :meth:`send_command` for the life of the process.
         """
         logger.debug("M->I: %s", message)
 
-        if self.recv_callback is not None:
-            self.recv_callback(message)
-        else:
-            self.queue.put_nowait(message)
+        if self.recv_callback is not None and self.recv_callback(message):
+            return
+
+        self.queue.put_nowait(message)
 
     def set_recv_callback(self, callback: Optional[Callable[[bytes], bool]]):
         self.recv_callback = callback
@@ -86,11 +91,34 @@ class GsmSerialConnection(Connection):
     def make_protocol(self):
         return GsmSerialProtocol(self)
 
-    async def send_command(self, message: bytes, timeout=DEFAULT_COMMAND_TIMEOUT):
-        """Send an AT command and wait for the modem's next line."""
+    async def send_command(
+        self,
+        message: bytes,
+        timeout=DEFAULT_COMMAND_TIMEOUT,
+        expect_prompt: bool = False,
+    ):
+        """Send an AT command and wait for the modem's next line.
+
+        Set ``expect_prompt`` when the command is answered by an unterminated
+        ``"> "`` entry prompt rather than by a line, as ``AT+CMGS`` is.
+        """
         logger.debug("I->M: %s", message)
+
+        if expect_prompt:
+            if self._protocol is None:
+                raise ConnectionError("Not connected")
+            self._protocol.expect_prompt()
+
         self.write(message)
         return await asyncio.wait_for(self.queue.get(), timeout=timeout)
+
+    def write_raw(self, message: bytes) -> None:
+        """Write bytes with no line terminator, for an SMS body."""
+        if not self.connected or self._protocol is None:
+            raise ConnectionError("Not connected")
+
+        logger.debug("I->M: %s (raw)", message)
+        self._protocol.send_raw(message)
 
     async def read(self, timeout=DEFAULT_COMMAND_TIMEOUT):
         if self._protocol is None:

--- a/paradox/connections/gsm/connection.py
+++ b/paradox/connections/gsm/connection.py
@@ -86,21 +86,10 @@ class GsmSerialConnection(Connection):
     def make_protocol(self):
         return GsmSerialProtocol(self)
 
-    def write(self, data: bytes):
-        """Unsupported: the modem channel is request/response.
-
-        ``Connection.write`` is a synchronous fire-and-forget that would leave
-        :meth:`GsmSerialProtocol.send_message`'s coroutine un-awaited.
-        """
-        raise NotImplementedError("Use send_command() for the modem channel")
-
     async def send_command(self, message: bytes, timeout=DEFAULT_COMMAND_TIMEOUT):
         """Send an AT command and wait for the modem's next line."""
-        if self._protocol is None:
-            return None
-
         logger.debug("I->M: %s", message)
-        await self._protocol.send_message(message)
+        self.write(message)
         return await asyncio.wait_for(self.queue.get(), timeout=timeout)
 
     async def read(self, timeout=DEFAULT_COMMAND_TIMEOUT):
@@ -122,14 +111,22 @@ class GsmSerialConnection(Connection):
         )
 
         try:
-            _, self._protocol = await serial_asyncio.create_serial_connection(
-                asyncio.get_running_loop(),
-                self.make_protocol,
-                self.port_path,
-                self.baud,
+            # The open itself is bounded too: open_timeout() only resolves the
+            # future, which does no good if create_serial_connection is what
+            # hangs -- connect() would not yet be awaiting it.
+            _, self._protocol = await asyncio.wait_for(
+                serial_asyncio.create_serial_connection(
+                    asyncio.get_running_loop(),
+                    self.make_protocol,
+                    self.port_path,
+                    self.baud,
+                ),
+                timeout=self.open_timeout_seconds,
             )
 
             return await self.connected_future
+        except asyncio.TimeoutError:
+            logger.error("Serial Port Timeout")
         except Exception:
             logger.exception("Unable to connect to GSM modem")
         finally:

--- a/paradox/connections/gsm/protocol.py
+++ b/paradox/connections/gsm/protocol.py
@@ -19,6 +19,10 @@ MAX_LINE_LENGTH = 1024
 
 TERMINATOR = b"\r\n"
 
+#: What the modem sends to ask for an SMS body. It is *not* terminated, so the
+#: line framer can never surface it on its own.
+PROMPT = b"> "
+
 
 class GsmSerialProtocol(ConnectionProtocol):
     """CRLF line framing and modem echo suppression for an AT-command modem.
@@ -32,6 +36,7 @@ class GsmSerialProtocol(ConnectionProtocol):
     def __init__(self, handler: ConnectionHandler):
         super().__init__(handler)
         self.last_message = b""
+        self._prompt_expected = False
         self._framer = LineFramer(
             terminator=TERMINATOR,
             max_line_length=MAX_LINE_LENGTH,
@@ -43,6 +48,24 @@ class GsmSerialProtocol(ConnectionProtocol):
         self.last_message = message
         self.transport.write(message + TERMINATOR)
 
+    def send_raw(self, message: bytes) -> None:
+        """Write bytes verbatim, without the AT line terminator.
+
+        An SMS body is ended by Ctrl-Z rather than ``<CR><LF>``; appending a
+        terminator would put a stray blank line into the message.
+        """
+        self.check_active()
+        self.transport.write(message)
+
+    def expect_prompt(self) -> None:
+        """Arm one-shot detection of the SMS entry prompt.
+
+        Scoped to a single command because ``"> "`` is indistinguishable from a
+        line that has merely not finished arriving. Only a caller that just
+        sent ``AT+CMGS`` knows a prompt is due.
+        """
+        self._prompt_expected = True
+
     def data_received(self, recv_data):
         for frame in self._framer.feed(recv_data):
             message = frame.data
@@ -51,12 +74,27 @@ class GsmSerialProtocol(ConnectionProtocol):
             if self._is_echo(message):
                 continue
 
-            try:
-                self.handler.on_message(message)
-            except Exception:
-                # A single unparseable line must not strand the frames behind
-                # it: they would sit in the buffer until the next byte arrives.
-                logger.exception("Error handling modem message")
+            self._dispatch(message)
+
+        self._check_for_prompt()
+
+    def _dispatch(self, message: bytes) -> None:
+        try:
+            self.handler.on_message(message)
+        except Exception:
+            # A single unparseable line must not strand the frames behind
+            # it: they would sit in the buffer until the next byte arrives.
+            logger.exception("Error handling modem message")
+
+    def _check_for_prompt(self) -> None:
+        """Surface an armed, unterminated ``"> "`` left over after framing."""
+        if not self._prompt_expected or self._framer.buffer.pending != PROMPT:
+            return
+
+        logger.debug("M->P: %s (prompt)", PROMPT)
+        self._prompt_expected = False
+        self._framer.reset()
+        self._dispatch(PROMPT)
 
     def _is_echo(self, message: bytes) -> bool:
         """True when ``message`` is the modem echoing back the last command.
@@ -76,6 +114,7 @@ class GsmSerialProtocol(ConnectionProtocol):
     def reset_framing(self) -> None:
         self._framer.reset()
         self.last_message = b""
+        self._prompt_expected = False
 
     @property
     def buffer(self) -> bytes:

--- a/paradox/connections/gsm/protocol.py
+++ b/paradox/connections/gsm/protocol.py
@@ -1,0 +1,87 @@
+"""Framing and echo suppression for an AT-command GSM modem.
+
+Pure asyncio glue over :class:`~paradox.connections.framing.LineFramer`: no
+AT-command knowledge lives here beyond the echo of the last write.
+"""
+
+import logging
+
+from paradox.connections.framing import LineFramer
+from paradox.connections.handler import ConnectionHandler
+from paradox.connections.protocol_base import ConnectionProtocol
+
+logger = logging.getLogger("PAI").getChild(__name__)
+
+#: AT responses are short, but a text-mode ``+CMT`` line carries a whole SMS:
+#: 140 octets of UCS2 hex-encoded payload plus the header. 1 KiB leaves room
+#: for that and for verbose ``AT+CMEE=2`` error strings.
+MAX_LINE_LENGTH = 1024
+
+TERMINATOR = b"\r\n"
+
+
+class GsmSerialProtocol(ConnectionProtocol):
+    """CRLF line framing and modem echo suppression for an AT-command modem.
+
+    Named apart from
+    :class:`paradox.connections.serial.protocol.SerialConnectionProtocol`
+    because the two are not substitutable: that one's ``send_message`` is
+    synchronous, this one's is a coroutine.
+    """
+
+    def __init__(self, handler: ConnectionHandler):
+        super().__init__(handler)
+        self.last_message = b""
+        self._framer = LineFramer(
+            terminator=TERMINATOR,
+            max_line_length=MAX_LINE_LENGTH,
+            strip_terminator=True,
+        )
+
+    async def send_message(self, message):
+        self.last_message = message
+        self.transport.write(message + TERMINATOR)
+
+    def data_received(self, recv_data):
+        for frame in self._framer.feed(recv_data):
+            message = frame.data
+            logger.debug("M->P: %s", message)
+
+            if self._is_echo(message):
+                continue
+
+            try:
+                self.handler.on_message(message)
+            except Exception:
+                # A single unparseable line must not strand the frames behind
+                # it: they would sit in the buffer until the next byte arrives.
+                logger.exception("Error handling modem message")
+
+    def _is_echo(self, message: bytes) -> bool:
+        """True when ``message`` is the modem echoing back the last command.
+
+        Echo suppression is scoped to the first line after a write. Echo is
+        normally off (``connect()`` issues ``ATE0``), so an expectation that
+        outlived its response would eventually swallow an unrelated line that
+        happened to match the last command.
+
+        The comparison tolerates a trailing ``\\r`` because many V.25ter modems
+        echo the command terminated by a bare ``<CR>`` and only then send
+        ``<CR><LF>OK<CR><LF>``.
+        """
+        expected, self.last_message = self.last_message, b""
+        return bool(expected) and message.rstrip(b"\r") == expected.rstrip(b"\r")
+
+    def reset_framing(self) -> None:
+        self._framer.reset()
+        self.last_message = b""
+
+    @property
+    def buffer(self) -> bytes:
+        """Unconsumed bytes. Retained for tests and diagnostics."""
+        return self._framer.buffer.pending
+
+    def connection_lost(self, exc):
+        logger.error("The serial port was closed")
+        self.last_message = b""
+        super().connection_lost(exc)

--- a/paradox/connections/gsm/protocol.py
+++ b/paradox/connections/gsm/protocol.py
@@ -23,10 +23,10 @@ TERMINATOR = b"\r\n"
 class GsmSerialProtocol(ConnectionProtocol):
     """CRLF line framing and modem echo suppression for an AT-command modem.
 
-    Named apart from
+    Kept distinct from
     :class:`paradox.connections.serial.protocol.SerialConnectionProtocol`
-    because the two are not substitutable: that one's ``send_message`` is
-    synchronous, this one's is a coroutine.
+    because the two framings have nothing in common: that one is a binary
+    nibble-pattern framer, this one is CRLF lines plus echo suppression.
     """
 
     def __init__(self, handler: ConnectionHandler):
@@ -38,7 +38,8 @@ class GsmSerialProtocol(ConnectionProtocol):
             strip_terminator=True,
         )
 
-    async def send_message(self, message):
+    def send_message(self, message):
+        self.check_active()
         self.last_message = message
         self.transport.write(message + TERMINATOR)
 

--- a/paradox/connections/gsm/protocol.py
+++ b/paradox/connections/gsm/protocol.py
@@ -1,8 +1,4 @@
-"""Framing and echo suppression for an AT-command GSM modem.
-
-Pure asyncio glue over :class:`~paradox.connections.framing.LineFramer`: no
-AT-command knowledge lives here beyond the echo of the last write.
-"""
+"""Framing and echo suppression for an AT-command GSM modem."""
 
 import logging
 
@@ -27,10 +23,9 @@ PROMPT = b"> "
 class GsmSerialProtocol(ConnectionProtocol):
     """CRLF line framing and modem echo suppression for an AT-command modem.
 
-    Kept distinct from
-    :class:`paradox.connections.serial.protocol.SerialConnectionProtocol`
-    because the two framings have nothing in common: that one is a binary
-    nibble-pattern framer, this one is CRLF lines plus echo suppression.
+    Distinct from
+    :class:`paradox.connections.serial.protocol.SerialConnectionProtocol`,
+    which frames the panel's binary nibble patterns.
     """
 
     def __init__(self, handler: ConnectionHandler):

--- a/paradox/connections/gsm/protocol.py
+++ b/paradox/connections/gsm/protocol.py
@@ -66,6 +66,10 @@ class GsmSerialProtocol(ConnectionProtocol):
         """
         self._prompt_expected = True
 
+    def disarm_prompt(self) -> None:
+        """Drop an expectation whose command did not survive to use it."""
+        self._prompt_expected = False
+
     def data_received(self, recv_data):
         for frame in self._framer.feed(recv_data):
             message = frame.data

--- a/paradox/connections/prt3/protocol.py
+++ b/paradox/connections/prt3/protocol.py
@@ -39,7 +39,7 @@ class PRT3Protocol(ConnectionProtocol):
         self._framer = LineFramer(
             terminator=b"\r",
             max_line_length=MAX_LINE_LENGTH,
-            drop_blank_lines=True,
+            drop_whitespace_lines=True,
         )
 
     def variable_message_length(self, *args, **kwargs):

--- a/paradox/connections/prt3/protocol.py
+++ b/paradox/connections/prt3/protocol.py
@@ -39,7 +39,7 @@ class PRT3Protocol(ConnectionProtocol):
         self._framer = LineFramer(
             terminator=b"\r",
             max_line_length=MAX_LINE_LENGTH,
-            drop_whitespace_lines=True,
+            drop_blank_lines=True,
         )
 
     def variable_message_length(self, *args, **kwargs):

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -1,15 +1,9 @@
 import asyncio
 import json
 import logging
-import os
-from typing import Callable, Optional
-
-import serial_asyncio
 
 from paradox.config import config as cfg
-from paradox.connections.connection import ConnectionProtocol
-from paradox.connections.framing import LineFramer
-from paradox.connections.handler import ConnectionHandler
+from paradox.connections.gsm.connection import GsmSerialConnection
 from paradox.event import EventLevel, Notification
 from paradox.interfaces.text.core import ConfiguredAbstractTextInterface
 from paradox.lib import ps
@@ -18,148 +12,6 @@ from paradox.lib import ps
 # Only exposes critical status changes and accepts commands
 
 logger = logging.getLogger("PAI").getChild(__name__)
-
-#: AT responses are short, but a text-mode ``+CMT`` line carries a whole SMS:
-#: 140 octets of UCS2 hex-encoded payload plus the header. 1 KiB leaves room
-#: for that and for verbose ``AT+CMEE=2`` error strings.
-MAX_LINE_LENGTH = 1024
-
-TERMINATOR = b"\r\n"
-
-
-class GsmSerialProtocol(ConnectionProtocol):
-    """CRLF line framing and modem echo suppression for an AT-command modem.
-
-    Named apart from
-    :class:`paradox.connections.serial.protocol.SerialConnectionProtocol`
-    because the two are not substitutable: that one's ``send_message`` is
-    synchronous, this one's is a coroutine.
-    """
-
-    def __init__(self, handler: ConnectionHandler):
-        super().__init__(handler)
-        self.last_message = b""
-        self._framer = LineFramer(
-            terminator=TERMINATOR,
-            max_line_length=MAX_LINE_LENGTH,
-            strip_terminator=True,
-        )
-
-    async def send_message(self, message):
-        self.last_message = message
-        self.transport.write(message + TERMINATOR)
-
-    def data_received(self, recv_data):
-        for frame in self._framer.feed(recv_data):
-            message = frame.data
-            logger.debug("M->P: %s", message)
-
-            if self._is_echo(message):
-                continue
-
-            try:
-                self.handler.on_message(message)
-            except Exception:
-                # A single unparseable line must not strand the frames behind
-                # it: they would sit in the buffer until the next byte arrives.
-                logger.exception("Error handling modem message")
-
-    def _is_echo(self, message: bytes) -> bool:
-        """True when ``message`` is the modem echoing back the last command.
-
-        Echo suppression is scoped to the first line after a write. Echo is
-        normally off (``connect()`` issues ``ATE0``), so an expectation that
-        outlived its response would eventually swallow an unrelated line that
-        happened to match the last command.
-
-        The comparison tolerates a trailing ``\\r`` because many V.25ter modems
-        echo the command terminated by a bare ``<CR>`` and only then send
-        ``<CR><LF>OK<CR><LF>``.
-        """
-        expected, self.last_message = self.last_message, b""
-        return bool(expected) and message.rstrip(b"\r") == expected.rstrip(b"\r")
-
-    def reset_framing(self) -> None:
-        self._framer.reset()
-        self.last_message = b""
-
-    @property
-    def buffer(self) -> bytes:
-        """Unconsumed bytes. Retained for tests and diagnostics."""
-        return self._framer.buffer.pending
-
-    def connection_lost(self, exc):
-        logger.error("The serial port was closed")
-        self.last_message = b""
-        super().connection_lost(exc)
-
-
-class SerialCommunication(ConnectionHandler):
-    def __init__(self, port, baud=9600, timeout=5):
-        self.port_path = port
-        self.baud = baud
-        self.connected_future = None
-        self.recv_callback = None
-        self.connected = False
-        self.connection = None
-        self.queue = asyncio.Queue()
-
-    def clear(self):
-        self.queue = asyncio.Queue()
-
-    def on_connection_loss(self):
-        logger.error("Connection was lost")
-        self.connected_future.set_result(False)
-        self.connected = False
-
-    def on_connection(self):
-        logger.info("Serial port open")
-        self.connected_future.set_result(True)
-        self.connected = True
-
-    def on_message(self, message: bytes):
-        logger.debug(f"M->I: {message}")
-
-        if self.recv_callback is not None:
-            self.recv_callback(message)  # Callback
-        else:
-            self.queue.put_nowait(message)
-
-    def set_recv_callback(self, callback: Optional[Callable[[str], bool]]):
-        self.recv_callback = callback
-
-    def open_timeout(self):
-        if self.connected_future.done():
-            return
-
-        logger.error("Serial Port Timeout")
-        self.connected_future.set_result(False)
-        self.connected = False
-
-    def make_protocol(self):
-        return GsmSerialProtocol(self)
-
-    async def write(self, message, timeout=15):
-        logger.debug(f"I->M: {message}")
-        if self.connection is not None:
-            await self.connection.send_message(message)
-            return await asyncio.wait_for(self.queue.get(), timeout=5)
-
-    async def read(self, timeout=5):
-        if self.connection is not None:
-            return await asyncio.wait_for(self.queue.get(), timeout=timeout)
-
-    async def connect(self):
-        logger.info(f"Connecting to serial port {self.port_path}")
-
-        self.connected_future = asyncio.get_running_loop().create_future()
-        asyncio.get_running_loop().call_later(5, self.open_timeout)
-
-        _, self.connection = await serial_asyncio.create_serial_connection(
-            asyncio.get_running_loop(), self.make_protocol, self.port_path, self.baud
-        )
-
-        return await self.connected_future
 
 
 class GSMTextInterface(ConfiguredAbstractTextInterface):
@@ -181,12 +33,21 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
     def stop(self):
         """Stops the GSM Interface"""
         super().stop()
-        logger.debug("GSM Stopped. TODO: Implement a proper stop")
+
+        if self.port is not None:
+            # stop() is synchronous, so the close can only be scheduled. The
+            # port is dropped either way: a half-closed port is still better
+            # than one held open for the life of the process.
+            port, self.port = self.port, None
+            self.modem_connected = False
+            self._loop.create_task(port.close())
+
+        logger.debug("GSM Stopped")
 
     async def write(self, message: str, expected: str = None) -> None:
         r = b""
         while r != expected:
-            r = await self.port.write(message)
+            r = await self.port.send_command(message)
             data = b""
 
             if r == b"ERROR":
@@ -198,24 +59,13 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
     async def connect(self):
         logger.info(f"Using {cfg.GSM_MODEM_PORT} at {cfg.GSM_MODEM_BAUDRATE} baud")
-        try:
-            if not os.path.exists(cfg.GSM_MODEM_PORT):
-                logger.error(f"Modem port ({cfg.GSM_MODEM_PORT}) not found")
-                return False
-
-            self.port = SerialCommunication(
-                cfg.GSM_MODEM_PORT, cfg.GSM_MODEM_BAUDRATE, 5
-            )
-
-        except Exception:
-            logger.exception(f"Could not open port {cfg.GSM_MODEM_PORT} for GSM modem")
-            return False
+        self.port = GsmSerialConnection(cfg.GSM_MODEM_PORT, cfg.GSM_MODEM_BAUDRATE, 5)
 
         self.port.set_recv_callback(None)
         result = await self.port.connect()
 
         if not result:
-            logger.exception("Could not connect to GSM modem")
+            logger.error("Could not connect to GSM modem")
             return False
 
         try:
@@ -310,7 +160,7 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             data = b'AT+CMGS="%b"\x0d%b\x1a' % (dst.encode(), message.encode())
 
             try:
-                result = await self.port.write(data)
+                result = await self.port.send_command(data)
                 logger.debug(f"SMS result: {result}")
             except Exception:
                 logger.exception("ERROR sending SMS")

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -59,7 +59,7 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
         """Stops the GSM Interface"""
         super().stop()
 
-        for task in list(self._send_tasks):
+        for task in self._send_tasks:
             task.cancel()
 
         if self.port is not None:
@@ -247,9 +247,10 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
         # and the Ctrl-Z the modem treats everything written as message text,
         # so a second sender would end up inside this SMS.
         async with self._command_lock:
-            prompt = await self.port.send_command(
-                b'AT+CMGS="%b"' % destination.encode(), expect_prompt=True
-            )
+            logger.debug("I->M: %s", destination)
+            self.port.clear()
+            self.port.write(b'AT+CMGS="%b"' % destination.encode())
+            prompt = await self.port.read(expect_prompt=True)
 
             if prompt != PROMPT:
                 # The modem may still be in entry mode; ESC leaves it cleanly

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -3,7 +3,10 @@ import json
 import logging
 
 from paradox.config import config as cfg
-from paradox.connections.gsm.connection import GsmSerialConnection
+from paradox.connections.gsm.connection import (
+    DEFAULT_COMMAND_TIMEOUT,
+    GsmSerialConnection,
+)
 from paradox.connections.gsm.protocol import PROMPT
 from paradox.event import EventLevel, Notification
 from paradox.interfaces.text.core import ConfiguredAbstractTextInterface
@@ -23,15 +26,11 @@ ESC = b"\x1b"
 #: Delivery to the network can be slow on a weak signal.
 SMS_SEND_TIMEOUT = 60
 
-#: Plain AT commands answer promptly or not at all.
-AT_COMMAND_TIMEOUT = 5
-
 #: How often to notice that the modem has gone away, and to retry a failed open.
 MODEM_POLL_INTERVAL = 5
 
-#: Final result codes. Everything else the modem emits is informational.
-_OK = b"OK"
-_ERRORS = (b"+CME ERROR", b"+CMS ERROR")
+#: Error result codes. Everything else the modem emits before OK is informational.
+ERRORS = (b"ERROR", b"+CME ERROR", b"+CMS ERROR")
 
 
 class GSMTextInterface(ConfiguredAbstractTextInterface):
@@ -73,10 +72,14 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
         logger.debug("GSM Stopped")
 
-    async def _at_command(self, command: bytes, timeout=AT_COMMAND_TIMEOUT) -> bytes:
+    async def _at_command(
+        self, command: bytes, timeout=DEFAULT_COMMAND_TIMEOUT
+    ) -> bytes:
         """Send one AT command and wait for its final result code."""
-        first = await self.port.send_command(command, timeout=timeout)
-        return await self._read_final_result(timeout, first_line=first)
+        logger.debug("I->M: %s", command)
+        self.port.clear()
+        self.port.write(command)
+        return await self._read_final_result(timeout)
 
     async def connect(self):
         logger.info(f"Using {cfg.GSM_MODEM_PORT} at {cfg.GSM_MODEM_BAUDRATE} baud")
@@ -137,11 +140,7 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
         await super().run()
 
         while True:
-            if (
-                self.modem_connected
-                and self.port is not None
-                and not self.port.connected
-            ):
+            if self.modem_connected and not self.port.connected:
                 # on_connection_loss only clears the transport's own flag, so
                 # the interface has to notice the drop and rebuild the port.
                 logger.warning("Modem connection lost")
@@ -267,31 +266,25 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
         logger.debug(f"SMS to {destination} result: {result}")
 
-    async def _read_final_result(self, timeout: float, first_line: bytes = None):
+    async def _read_final_result(self, timeout: float) -> bytes:
         """Read modem lines until a final result code.
 
         Sending can take the best part of a minute on a weak network, and the
         modem interleaves informational lines such as ``+CMGS: 42`` before the
-        closing ``OK``. ``first_line`` lets a caller hand over a line it has
-        already taken off the queue.
+        closing ``OK``.
         """
-        deadline = self._loop.time() + timeout
-        line = first_line
 
-        while True:
-            if line is not None:
-                if line == _OK:
+        async def until_final():
+            while True:
+                line = await self.port.read(timeout=None)
+                if line is None:
+                    raise ConnectionError("Modem disconnected")
+                if line == b"OK":
                     return line
-                if line == b"ERROR" or line.startswith(_ERRORS):
+                if line.startswith(ERRORS):
                     raise ValueError(f"Modem rejected the command: {line!r}")
 
-            remaining = deadline - self._loop.time()
-            if remaining <= 0:
-                raise asyncio.TimeoutError("No final result code from modem")
-
-            line = await self.port.read(timeout=remaining)
-            if line is None:
-                raise ConnectionError("Modem disconnected")
+        return await asyncio.wait_for(until_final(), timeout)
 
     def process_cmt(self, header: str, text: str) -> None:
         idx = header.find(" ")

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -26,7 +26,6 @@ ESC = b"\x1b"
 #: Delivery to the network can be slow on a weak signal.
 SMS_SEND_TIMEOUT = 60
 
-#: How often to notice that the modem has gone away, and to retry a failed open.
 MODEM_POLL_INTERVAL = 5
 
 #: Error result codes. Everything else the modem emits before OK is informational.
@@ -98,7 +97,7 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             # Held across the whole sequence: a half-initialised modem must not
             # see an SMS interleaved between these commands.
             async with self._command_lock:
-                await self._at_command(b"AT")  # Init
+                await self._at_command(b"AT")
                 await self._at_command(b"ATE0")  # Disable Echo
                 await self._at_command(b"AT+CMEE=2")  # Increase verbosity
                 await self._at_command(b"AT+CMGF=1")  # SMS Text mode
@@ -116,9 +115,7 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             logger.exception("Modem connect error")
             return False
 
-        self.port.set_recv_callback(
-            self.data_received
-        )  # Set recv callback to handle future messages
+        self.port.set_recv_callback(self.data_received)
 
         logger.debug("Modem connected")
         self.modem_connected = True
@@ -214,7 +211,7 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
         Synchronous to match :class:`AbstractTextInterface`, which is called
         straight from the pubsub handlers. Declaring this ``async`` made every
-        notification build a coroutine that nobody ever awaited.
+        notification build a coroutine that nobody awaited.
         """
         if self.port is None or not self.modem_connected:
             logger.warning("GSM not available when sending message")
@@ -240,8 +237,8 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
         The exchange is two-stage: ``AT+CMGS`` is answered by a ``"> "`` entry
         prompt, and only then does the modem accept the body, terminated by
-        Ctrl-Z. Sending both at once -- as this did -- leaves the modem sitting
-        in entry mode and the message unsent.
+        Ctrl-Z. Sending both at once leaves the modem sitting in entry mode and
+        the message unsent.
         """
         # Held for the whole exchange, not just the command: between the prompt
         # and the Ctrl-Z the modem treats everything written as message text,

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -23,6 +23,16 @@ ESC = b"\x1b"
 #: Delivery to the network can be slow on a weak signal.
 SMS_SEND_TIMEOUT = 60
 
+#: Plain AT commands answer promptly or not at all.
+AT_COMMAND_TIMEOUT = 5
+
+#: How often to notice that the modem has gone away, and to retry a failed open.
+MODEM_POLL_INTERVAL = 5
+
+#: Final result codes. Everything else the modem emits is informational.
+_OK = b"OK"
+_ERRORS = (b"+CME ERROR", b"+CMS ERROR")
+
 
 class GSMTextInterface(ConfiguredAbstractTextInterface):
     """Interface Class using GSM"""
@@ -40,9 +50,18 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
         self.modem_connected = False
         self.message_cmt = None
 
+        # The modem answers one command at a time and the reply queue cannot
+        # tell two callers apart, so every exchange is serialised here rather
+        # than in the transport -- an SMS spans several transport calls.
+        self._command_lock = asyncio.Lock()
+        self._send_tasks = set()
+
     def stop(self):
         """Stops the GSM Interface"""
         super().stop()
+
+        for task in list(self._send_tasks):
+            task.cancel()
 
         if self.port is not None:
             # stop() is synchronous, so the close can only be scheduled. The
@@ -54,21 +73,15 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
         logger.debug("GSM Stopped")
 
-    async def write(self, message: str, expected: str = None) -> None:
-        r = b""
-        while r != expected:
-            r = await self.port.send_command(message)
-            data = b""
-
-            if r == b"ERROR":
-                raise Exception(f"Got error from modem: {r}")
-
-            while r != expected:
-                r = await self.port.read()
-                data += r + b"\n"
+    async def _at_command(self, command: bytes, timeout=AT_COMMAND_TIMEOUT) -> bytes:
+        """Send one AT command and wait for its final result code."""
+        first = await self.port.send_command(command, timeout=timeout)
+        return await self._read_final_result(timeout, first_line=first)
 
     async def connect(self):
         logger.info(f"Using {cfg.GSM_MODEM_PORT} at {cfg.GSM_MODEM_BAUDRATE} baud")
+
+        await self._close_port()
         self.port = GsmSerialConnection(cfg.GSM_MODEM_PORT, cfg.GSM_MODEM_BAUDRATE, 5)
 
         self.port.set_recv_callback(None)
@@ -79,15 +92,18 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             return False
 
         try:
-            await self.write(b"AT", b"OK")  # Init
-            await self.write(b"ATE0", b"OK")  # Disable Echo
-            await self.write(b"AT+CMEE=2", b"OK")  # Increase verbosity
-            await self.write(b"AT+CMGF=1", b"OK")  # SMS Text mode
-            await self.write(b"AT+CFUN=1", b"OK")  # Enable modem
-            await self.write(
-                b"AT+CNMI=1,2,0,0,0", b"OK"
-            )  # SMS received only when modem enabled, Use +CMT with SMS, No Status Report,
-            await self.write(b"AT+CUSD=1", b"OK")  # Enable result code presentation
+            # Held across the whole sequence: a half-initialised modem must not
+            # see an SMS interleaved between these commands.
+            async with self._command_lock:
+                await self._at_command(b"AT")  # Init
+                await self._at_command(b"ATE0")  # Disable Echo
+                await self._at_command(b"AT+CMEE=2")  # Increase verbosity
+                await self._at_command(b"AT+CMGF=1")  # SMS Text mode
+                await self._at_command(b"AT+CFUN=1")  # Enable modem
+                # SMS delivered only while the modem is enabled, body carried
+                # in +CMT, no status report.
+                await self._at_command(b"AT+CNMI=1,2,0,0,0")
+                await self._at_command(b"AT+CUSD=1")  # Result code presentation
 
         except asyncio.TimeoutError:
             logger.error("No reply from modem")
@@ -105,14 +121,36 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
         self.modem_connected = True
         return True
 
+    async def _close_port(self) -> None:
+        """Drop the previous port, so a retry does not leak the last attempt."""
+        if self.port is None:
+            return
+
+        port, self.port = self.port, None
+        self.modem_connected = False
+        try:
+            await port.close()
+        except Exception:
+            logger.exception("Error closing GSM modem port")
+
     async def run(self):
         await super().run()
 
-        while not self.modem_connected:
-            if not await self.connect():
+        while True:
+            if (
+                self.modem_connected
+                and self.port is not None
+                and not self.port.connected
+            ):
+                # on_connection_loss only clears the transport's own flag, so
+                # the interface has to notice the drop and rebuild the port.
+                logger.warning("Modem connection lost")
+                self.modem_connected = False
+
+            if not self.modem_connected and not await self.connect():
                 logger.warning("Could not connect to modem")
 
-            await asyncio.sleep(5)
+            await asyncio.sleep(MODEM_POLL_INTERVAL)
 
     def data_received(self, raw: bytes) -> bool:
         """Handle an unsolicited modem line.
@@ -183,12 +221,18 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             logger.warning("GSM not available when sending message")
             return
 
-        self._loop.create_task(self._send_sms_to_contacts(message))
+        task = self._loop.create_task(self._send_sms_to_contacts(message))
+        # Tracked so stop() can cancel them, and so the loop keeps a strong
+        # reference: asyncio only holds a weak one.
+        self._send_tasks.add(task)
+        task.add_done_callback(self._send_tasks.discard)
 
     async def _send_sms_to_contacts(self, message: str) -> None:
         for dst in cfg.GSM_CONTACTS:
             try:
                 await self._send_sms(dst, message)
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 logger.exception("ERROR sending SMS to %s", dst)
 
@@ -200,44 +244,54 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
         Ctrl-Z. Sending both at once -- as this did -- leaves the modem sitting
         in entry mode and the message unsent.
         """
-        prompt = await self.port.send_command(
-            b'AT+CMGS="%b"' % destination.encode(), expect_prompt=True
-        )
+        # Held for the whole exchange, not just the command: between the prompt
+        # and the Ctrl-Z the modem treats everything written as message text,
+        # so a second sender would end up inside this SMS.
+        async with self._command_lock:
+            prompt = await self.port.send_command(
+                b'AT+CMGS="%b"' % destination.encode(), expect_prompt=True
+            )
 
-        if prompt != PROMPT:
-            # The modem may still be in entry mode; ESC leaves it cleanly
-            # rather than letting the next command become SMS text.
-            self.port.write_raw(ESC)
-            raise ValueError(f"Modem did not ask for an SMS body: {prompt!r}")
+            if prompt != PROMPT:
+                # The modem may still be in entry mode; ESC leaves it cleanly
+                # rather than letting the next command become SMS text.
+                self.port.write_raw(ESC)
+                raise ValueError(f"Modem did not ask for an SMS body: {prompt!r}")
 
-        self.port.write_raw(message.encode() + CTRL_Z)
+            try:
+                self.port.write_raw(message.encode() + CTRL_Z)
+                result = await self._read_final_result(SMS_SEND_TIMEOUT)
+            except asyncio.TimeoutError:
+                self.port.write_raw(ESC)
+                raise
 
-        result = await self._read_final_result(SMS_SEND_TIMEOUT)
         logger.debug(f"SMS to {destination} result: {result}")
 
-    async def _read_final_result(self, timeout: float) -> bytes:
-        """Drain modem lines until a final result code.
+    async def _read_final_result(self, timeout: float, first_line: bytes = None):
+        """Read modem lines until a final result code.
 
         Sending can take the best part of a minute on a weak network, and the
         modem interleaves informational lines such as ``+CMGS: 42`` before the
-        closing ``OK``.
+        closing ``OK``. ``first_line`` lets a caller hand over a line it has
+        already taken off the queue.
         """
         deadline = self._loop.time() + timeout
+        line = first_line
 
         while True:
+            if line is not None:
+                if line == _OK:
+                    return line
+                if line == b"ERROR" or line.startswith(_ERRORS):
+                    raise ValueError(f"Modem rejected the command: {line!r}")
+
             remaining = deadline - self._loop.time()
             if remaining <= 0:
                 raise asyncio.TimeoutError("No final result code from modem")
 
             line = await self.port.read(timeout=remaining)
             if line is None:
-                raise ConnectionError("Modem disconnected while sending")
-
-            if line == b"OK":
-                return line
-
-            if line == b"ERROR" or line.startswith((b"+CME ERROR", b"+CMS ERROR")):
-                raise ValueError(f"Modem rejected the SMS: {line!r}")
+                raise ConnectionError("Modem disconnected")
 
     def process_cmt(self, header: str, text: str) -> None:
         idx = header.find(" ")

--- a/paradox/interfaces/text/gsm.py
+++ b/paradox/interfaces/text/gsm.py
@@ -4,6 +4,7 @@ import logging
 
 from paradox.config import config as cfg
 from paradox.connections.gsm.connection import GsmSerialConnection
+from paradox.connections.gsm.protocol import PROMPT
 from paradox.event import EventLevel, Notification
 from paradox.interfaces.text.core import ConfiguredAbstractTextInterface
 from paradox.lib import ps
@@ -12,6 +13,15 @@ from paradox.lib import ps
 # Only exposes critical status changes and accepts commands
 
 logger = logging.getLogger("PAI").getChild(__name__)
+
+#: Ends an SMS body and hands it to the modem for sending.
+CTRL_Z = b"\x1a"
+
+#: Abandons SMS entry mode without sending.
+ESC = b"\x1b"
+
+#: Delivery to the network can be slow on a weak signal.
+SMS_SEND_TIMEOUT = 60
 
 
 class GSMTextInterface(ConfiguredAbstractTextInterface):
@@ -105,6 +115,12 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             await asyncio.sleep(5)
 
     def data_received(self, raw: bytes) -> bool:
+        """Handle an unsolicited modem line.
+
+        Returns whether the line was consumed. Anything declined here is a
+        reply to a command in flight and falls through to the connection's
+        queue, which is what lets :meth:`_send_sms` see its own responses.
+        """
         logger.debug(f"Data Received: {raw}")
 
         try:
@@ -116,7 +132,9 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
 
         if data.startswith("+CMT"):
             self.message_cmt = data
-        elif self.message_cmt is not None:
+            return True
+
+        if self.message_cmt is not None:
             # Clear before parsing: a header left in place after a failure
             # would capture every following line as its SMS body.
             header, self.message_cmt = self.message_cmt, None
@@ -124,13 +142,16 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
                 self.process_cmt(header, data)
             except (ValueError, IndexError):
                 logger.warning("Discarding malformed +CMT message: %r", header)
-        elif data.startswith("+CUSD:"):
+            return True
+
+        if data.startswith("+CUSD:"):
             try:
                 self.process_cusd(data)
             except (ValueError, IndexError):
                 logger.warning("Discarding malformed +CUSD message: %r", data)
+            return True
 
-        return True
+        return False
 
     async def handle_message(self, timestamp: str, source: str, message: str) -> None:
         """Handle GSM message. It should be a command"""
@@ -151,19 +172,72 @@ class GSMTextInterface(ConfiguredAbstractTextInterface):
             Notification(sender=self.name, message=m, level=EventLevel.INFO)
         )
 
-    async def send_message(self, message: str, level: EventLevel) -> None:
-        if self.port is None:
+    def send_message(self, message: str, level: EventLevel) -> None:
+        """Queue an SMS to every configured contact.
+
+        Synchronous to match :class:`AbstractTextInterface`, which is called
+        straight from the pubsub handlers. Declaring this ``async`` made every
+        notification build a coroutine that nobody ever awaited.
+        """
+        if self.port is None or not self.modem_connected:
             logger.warning("GSM not available when sending message")
             return
 
-        for dst in cfg.GSM_CONTACTS:
-            data = b'AT+CMGS="%b"\x0d%b\x1a' % (dst.encode(), message.encode())
+        self._loop.create_task(self._send_sms_to_contacts(message))
 
+    async def _send_sms_to_contacts(self, message: str) -> None:
+        for dst in cfg.GSM_CONTACTS:
             try:
-                result = await self.port.send_command(data)
-                logger.debug(f"SMS result: {result}")
+                await self._send_sms(dst, message)
             except Exception:
-                logger.exception("ERROR sending SMS")
+                logger.exception("ERROR sending SMS to %s", dst)
+
+    async def _send_sms(self, destination: str, message: str) -> None:
+        """Send one text-mode SMS.
+
+        The exchange is two-stage: ``AT+CMGS`` is answered by a ``"> "`` entry
+        prompt, and only then does the modem accept the body, terminated by
+        Ctrl-Z. Sending both at once -- as this did -- leaves the modem sitting
+        in entry mode and the message unsent.
+        """
+        prompt = await self.port.send_command(
+            b'AT+CMGS="%b"' % destination.encode(), expect_prompt=True
+        )
+
+        if prompt != PROMPT:
+            # The modem may still be in entry mode; ESC leaves it cleanly
+            # rather than letting the next command become SMS text.
+            self.port.write_raw(ESC)
+            raise ValueError(f"Modem did not ask for an SMS body: {prompt!r}")
+
+        self.port.write_raw(message.encode() + CTRL_Z)
+
+        result = await self._read_final_result(SMS_SEND_TIMEOUT)
+        logger.debug(f"SMS to {destination} result: {result}")
+
+    async def _read_final_result(self, timeout: float) -> bytes:
+        """Drain modem lines until a final result code.
+
+        Sending can take the best part of a minute on a weak network, and the
+        modem interleaves informational lines such as ``+CMGS: 42`` before the
+        closing ``OK``.
+        """
+        deadline = self._loop.time() + timeout
+
+        while True:
+            remaining = deadline - self._loop.time()
+            if remaining <= 0:
+                raise asyncio.TimeoutError("No final result code from modem")
+
+            line = await self.port.read(timeout=remaining)
+            if line is None:
+                raise ConnectionError("Modem disconnected while sending")
+
+            if line == b"OK":
+                return line
+
+            if line == b"ERROR" or line.startswith((b"+CME ERROR", b"+CMS ERROR")):
+                raise ValueError(f"Modem rejected the SMS: {line!r}")
 
     def process_cmt(self, header: str, text: str) -> None:
         idx = header.find(" ")

--- a/tests/connection/gsm/test_connection.py
+++ b/tests/connection/gsm/test_connection.py
@@ -25,13 +25,30 @@ async def connected_gsm_connection():
         new_callable=mock.AsyncMock,
         side_effect=mocked_create_serial_connection,
     ):
-        asyncio.get_event_loop().call_soon(comm.on_connection)
         result = await comm.connect()
         assert result
 
     assert comm.connected
 
     return comm
+
+
+@pytest.mark.asyncio
+async def test_connect_gives_up_when_the_port_open_hangs():
+    """A hung create_serial_connection must not block connect() forever."""
+    comm = GsmSerialConnection("test_port", 9600, 0.01)
+
+    async def never_opens(*args, **kwargs):
+        await asyncio.sleep(10)
+
+    with mock.patch("os.access", return_value=True), mock.patch(
+        "serial_asyncio.create_serial_connection",
+        new_callable=mock.AsyncMock,
+        side_effect=never_opens,
+    ):
+        assert await comm.connect() is False
+
+    assert not comm.connected
 
 
 @pytest.mark.asyncio
@@ -81,10 +98,14 @@ async def test_send_command_honours_its_timeout(connected_gsm_connection):
 
 
 @pytest.mark.asyncio
-async def test_write_is_rejected(connected_gsm_connection):
-    """Connection.write() would leave send_message's coroutine un-awaited."""
-    with pytest.raises(NotImplementedError):
-        connected_gsm_connection.write(b"AT")
+async def test_write_reaches_the_transport(connected_gsm_connection):
+    """Connection.write() is inherited now that send_message is synchronous."""
+    comm = connected_gsm_connection
+
+    with mock.patch.object(comm._protocol, "transport") as transport:
+        comm.write(b"AT")
+
+    transport.write.assert_called_once_with(b"AT\r\n")
 
 
 @pytest.mark.asyncio

--- a/tests/connection/gsm/test_connection.py
+++ b/tests/connection/gsm/test_connection.py
@@ -149,7 +149,7 @@ async def test_clear_replaces_the_queue(connected_gsm_connection):
 async def test_a_declined_line_still_reaches_the_command_waiter(
     connected_gsm_connection,
 ):
-    """Routing every line to the callback used to starve send_command forever."""
+    """Routing every line to the callback used to starve command waiters."""
     comm = connected_gsm_connection
     comm.set_recv_callback(lambda message: message.startswith(b"+CMT"))
 

--- a/tests/connection/gsm/test_connection.py
+++ b/tests/connection/gsm/test_connection.py
@@ -151,3 +151,63 @@ async def test_clear_replaces_the_queue(connected_gsm_connection):
     comm.clear()
 
     assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_a_declined_line_still_reaches_the_command_waiter(
+    connected_gsm_connection,
+):
+    """Routing every line to the callback used to starve send_command forever."""
+    comm = connected_gsm_connection
+    comm.set_recv_callback(lambda message: message.startswith(b"+CMT"))
+
+    comm.on_message(b"+CMT: unsolicited")
+    comm.on_message(b"OK")
+
+    assert await comm.read(timeout=0.1) == b"OK"
+    assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_a_consumed_line_is_not_queued(connected_gsm_connection):
+    comm = connected_gsm_connection
+    consumed = []
+
+    def callback(message):
+        consumed.append(message)
+        return True
+
+    comm.set_recv_callback(callback)
+    comm.on_message(b"+CUSD: 1")
+
+    assert consumed == [b"+CUSD: 1"]
+    assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_send_command_can_arm_the_sms_prompt(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    with mock.patch.object(comm._protocol, "expect_prompt") as expect_prompt:
+        asyncio.get_event_loop().call_soon(comm.on_message, b"> ")
+        assert await comm.send_command(b'AT+CMGS="+1"', expect_prompt=True) == b"> "
+
+    expect_prompt.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_write_raw_bypasses_the_line_terminator(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    with mock.patch.object(comm._protocol, "transport") as transport:
+        comm.write_raw(b"body\x1a")
+
+    transport.write.assert_called_once_with(b"body\x1a")
+
+
+@pytest.mark.asyncio
+async def test_write_raw_requires_a_connection():
+    comm = GsmSerialConnection("test_port", 9600, 5)
+
+    with pytest.raises(ConnectionError):
+        comm.write_raw(b"body\x1a")

--- a/tests/connection/gsm/test_connection.py
+++ b/tests/connection/gsm/test_connection.py
@@ -1,0 +1,132 @@
+"""Tests for the GSM modem serial transport."""
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from paradox.connections.gsm.connection import GsmSerialConnection
+
+
+@pytest.fixture
+async def connected_gsm_connection():
+    comm = GsmSerialConnection("test_port", 9600, 5)
+
+    assert comm.queue.empty()
+
+    async def mocked_create_serial_connection(loop, protocol_factory, *args, **kwargs):
+        transport = mock.Mock()
+        protocol = comm.make_protocol()
+        asyncio.get_event_loop().call_soon(protocol.connection_made, transport)
+        return (transport, protocol)
+
+    with mock.patch("os.access", return_value=True), mock.patch(
+        "serial_asyncio.create_serial_connection",
+        new_callable=mock.AsyncMock,
+        side_effect=mocked_create_serial_connection,
+    ):
+        asyncio.get_event_loop().call_soon(comm.on_connection)
+        result = await comm.connect()
+        assert result
+
+    assert comm.connected
+
+    return comm
+
+
+@pytest.mark.asyncio
+async def test_send_command_returns_the_next_modem_line(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    asyncio.get_event_loop().call_soon(comm.on_message, b"OK")
+    assert await comm.send_command(b"AT") == b"OK"
+
+
+@pytest.mark.asyncio
+async def test_read_drains_the_queue(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    asyncio.get_event_loop().call_soon(comm.on_message, b"read_message")
+    assert await comm.read() == b"read_message"
+    assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_recv_callback_takes_precedence_over_the_queue(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    callback = mock.MagicMock()
+    comm.set_recv_callback(callback)
+    comm.on_message(b"+CMT: unsolicited")
+
+    callback.assert_called_once_with(b"+CMT: unsolicited")
+    assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_send_command_honours_its_timeout(connected_gsm_connection):
+    """The timeout argument used to be accepted and then ignored.
+
+    The old code hardcoded ``wait_for(..., timeout=5)``, so this raised too,
+    just five seconds later. The elapsed check is what pins the fix.
+    """
+    comm = connected_gsm_connection
+
+    loop = asyncio.get_event_loop()
+    started = loop.time()
+    with pytest.raises(asyncio.TimeoutError):
+        await comm.send_command(b"AT", timeout=0.01)
+
+    assert loop.time() - started < 1
+
+
+@pytest.mark.asyncio
+async def test_write_is_rejected(connected_gsm_connection):
+    """Connection.write() would leave send_message's coroutine un-awaited."""
+    with pytest.raises(NotImplementedError):
+        connected_gsm_connection.write(b"AT")
+
+
+@pytest.mark.asyncio
+async def test_connection_loss_after_connect_does_not_raise(connected_gsm_connection):
+    """The connected_future is already resolved by then."""
+    comm = connected_gsm_connection
+
+    comm.on_connection_loss()
+
+    assert not comm.connected
+
+
+@pytest.mark.asyncio
+async def test_connect_fails_when_the_port_is_not_accessible():
+    comm = GsmSerialConnection("test_port", 9600, 5)
+
+    with mock.patch("os.access", return_value=False):
+        assert await comm.connect() is False
+
+
+@pytest.mark.asyncio
+async def test_connect_gives_up_after_the_open_timeout():
+    comm = GsmSerialConnection("test_port", 9600, 0.01)
+
+    async def never_connects(loop, protocol_factory, *args, **kwargs):
+        return (mock.Mock(), comm.make_protocol())
+
+    with mock.patch("os.access", return_value=True), mock.patch(
+        "serial_asyncio.create_serial_connection",
+        new_callable=mock.AsyncMock,
+        side_effect=never_connects,
+    ):
+        assert await comm.connect() is False
+
+    assert not comm.connected
+
+
+@pytest.mark.asyncio
+async def test_clear_replaces_the_queue(connected_gsm_connection):
+    comm = connected_gsm_connection
+
+    comm.on_message(b"stale")
+    comm.clear()
+
+    assert comm.queue.empty()

--- a/tests/connection/gsm/test_connection.py
+++ b/tests/connection/gsm/test_connection.py
@@ -211,3 +211,54 @@ async def test_write_raw_requires_a_connection():
 
     with pytest.raises(ConnectionError):
         comm.write_raw(b"body\x1a")
+
+
+@pytest.mark.asyncio
+async def test_a_stale_reply_does_not_satisfy_the_next_command(
+    connected_gsm_connection,
+):
+    """The late answer to a timed-out command used to be handed to the next."""
+    comm = connected_gsm_connection
+
+    with mock.patch.object(comm._protocol, "transport"):
+        with pytest.raises(asyncio.TimeoutError):
+            await comm.send_command(b"AT+A", timeout=0.01)
+
+        comm.on_message(b"late-reply-to-A")
+
+        asyncio.get_event_loop().call_soon(comm.on_message, b"reply-to-B")
+        assert await comm.send_command(b"AT+B", timeout=0.5) == b"reply-to-B"
+
+
+@pytest.mark.asyncio
+async def test_a_timed_out_command_disarms_the_prompt(connected_gsm_connection):
+    """A stuck expectation would read the next unterminated line as a prompt."""
+    comm = connected_gsm_connection
+
+    with mock.patch.object(comm._protocol, "transport"):
+        with pytest.raises(asyncio.TimeoutError):
+            await comm.send_command(b'AT+CMGS="+1"', timeout=0.01, expect_prompt=True)
+
+    assert comm._protocol._prompt_expected is False
+
+
+@pytest.mark.asyncio
+async def test_send_command_requires_a_connection():
+    comm = GsmSerialConnection("test_port", 9600, 5)
+
+    with pytest.raises(ConnectionError):
+        await comm.send_command(b"AT")
+
+
+@pytest.mark.asyncio
+async def test_clear_keeps_a_waiter_attached(connected_gsm_connection):
+    """Replacing the queue object stranded anyone already blocked in read()."""
+    comm = connected_gsm_connection
+
+    reader = asyncio.ensure_future(comm.read(timeout=0.5))
+    await asyncio.sleep(0)
+
+    comm.clear()
+    comm.on_message(b"OK")
+
+    assert await reader == b"OK"

--- a/tests/connection/gsm/test_connection.py
+++ b/tests/connection/gsm/test_connection.py
@@ -52,14 +52,6 @@ async def test_connect_gives_up_when_the_port_open_hangs():
 
 
 @pytest.mark.asyncio
-async def test_send_command_returns_the_next_modem_line(connected_gsm_connection):
-    comm = connected_gsm_connection
-
-    asyncio.get_event_loop().call_soon(comm.on_message, b"OK")
-    assert await comm.send_command(b"AT") == b"OK"
-
-
-@pytest.mark.asyncio
 async def test_read_drains_the_queue(connected_gsm_connection):
     comm = connected_gsm_connection
 
@@ -81,7 +73,7 @@ async def test_recv_callback_takes_precedence_over_the_queue(connected_gsm_conne
 
 
 @pytest.mark.asyncio
-async def test_send_command_honours_its_timeout(connected_gsm_connection):
+async def test_read_honours_its_timeout(connected_gsm_connection):
     """The timeout argument used to be accepted and then ignored.
 
     The old code hardcoded ``wait_for(..., timeout=5)``, so this raised too,
@@ -92,7 +84,7 @@ async def test_send_command_honours_its_timeout(connected_gsm_connection):
     loop = asyncio.get_event_loop()
     started = loop.time()
     with pytest.raises(asyncio.TimeoutError):
-        await comm.send_command(b"AT", timeout=0.01)
+        await comm.read(timeout=0.01)
 
     assert loop.time() - started < 1
 
@@ -185,12 +177,12 @@ async def test_a_consumed_line_is_not_queued(connected_gsm_connection):
 
 
 @pytest.mark.asyncio
-async def test_send_command_can_arm_the_sms_prompt(connected_gsm_connection):
+async def test_read_can_arm_the_sms_prompt(connected_gsm_connection):
     comm = connected_gsm_connection
 
     with mock.patch.object(comm._protocol, "expect_prompt") as expect_prompt:
         asyncio.get_event_loop().call_soon(comm.on_message, b"> ")
-        assert await comm.send_command(b'AT+CMGS="+1"', expect_prompt=True) == b"> "
+        assert await comm.read(expect_prompt=True) == b"> "
 
     expect_prompt.assert_called_once_with()
 
@@ -214,40 +206,14 @@ async def test_write_raw_requires_a_connection():
 
 
 @pytest.mark.asyncio
-async def test_a_stale_reply_does_not_satisfy_the_next_command(
-    connected_gsm_connection,
-):
-    """The late answer to a timed-out command used to be handed to the next."""
-    comm = connected_gsm_connection
-
-    with mock.patch.object(comm._protocol, "transport"):
-        with pytest.raises(asyncio.TimeoutError):
-            await comm.send_command(b"AT+A", timeout=0.01)
-
-        comm.on_message(b"late-reply-to-A")
-
-        asyncio.get_event_loop().call_soon(comm.on_message, b"reply-to-B")
-        assert await comm.send_command(b"AT+B", timeout=0.5) == b"reply-to-B"
-
-
-@pytest.mark.asyncio
-async def test_a_timed_out_command_disarms_the_prompt(connected_gsm_connection):
+async def test_a_timed_out_read_disarms_the_prompt(connected_gsm_connection):
     """A stuck expectation would read the next unterminated line as a prompt."""
     comm = connected_gsm_connection
 
-    with mock.patch.object(comm._protocol, "transport"):
-        with pytest.raises(asyncio.TimeoutError):
-            await comm.send_command(b'AT+CMGS="+1"', timeout=0.01, expect_prompt=True)
+    with pytest.raises(asyncio.TimeoutError):
+        await comm.read(timeout=0.01, expect_prompt=True)
 
     assert comm._protocol._prompt_expected is False
-
-
-@pytest.mark.asyncio
-async def test_send_command_requires_a_connection():
-    comm = GsmSerialConnection("test_port", 9600, 5)
-
-    with pytest.raises(ConnectionError):
-        await comm.send_command(b"AT")
 
 
 @pytest.mark.asyncio

--- a/tests/connection/gsm/test_protocol.py
+++ b/tests/connection/gsm/test_protocol.py
@@ -1,0 +1,149 @@
+"""Tests for the GSM modem line protocol."""
+
+from unittest import mock
+
+import pytest
+
+from paradox.connections.gsm.protocol import MAX_LINE_LENGTH, GsmSerialProtocol
+
+
+# Test GsmSerialProtocol class
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    transport = mock.MagicMock()
+    protocol.connection_made(transport)
+    handler.on_connection.assert_called_once()
+
+    message = b"test_message"
+    await protocol.send_message(message)
+    transport.write.assert_called_once_with(message + b"\r\n")
+
+    recv_data = b"test_data\r\n"
+    protocol.data_received(recv_data)
+    handler.on_message.assert_called_once_with(b"test_data")
+
+    exc = Exception("test_exception")
+    protocol.connection_lost(exc)
+    handler.on_connection_loss.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_reassembles_split_frames():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    protocol.data_received(b"par")
+    handler.on_message.assert_not_called()
+
+    protocol.data_received(b"tial\r\n\r\nOK\r\ntrail")
+
+    assert handler.on_message.call_args_list == [
+        mock.call(b"partial"),
+        mock.call(b"OK"),
+    ]
+    assert protocol.buffer == b"trail"
+
+    protocol.reset_framing()
+    assert protocol.buffer == b""
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_drops_echoed_message():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"AT\r\nOK\r\n")
+
+    handler.on_message.assert_called_once_with(b"OK")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_drops_cr_terminated_echo():
+    """Many V.25ter modems echo the command terminated by a bare CR."""
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"AT\r\r\nOK\r\n")
+
+    handler.on_message.assert_called_once_with(b"OK")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_echo_expectation_is_not_sticky():
+    """Echo is off after ATE0, so the expectation must die with the response."""
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT+CUSD=1")
+    protocol.data_received(b"OK\r\n")
+    protocol.data_received(b"AT+CUSD=1\r\n")
+
+    assert handler.on_message.call_args_list == [
+        mock.call(b"OK"),
+        mock.call(b"AT+CUSD=1"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_only_checks_the_first_frame_for_echo():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.data_received(b"OK\r\nAT\r\n")
+
+    assert handler.on_message.call_args_list == [mock.call(b"OK"), mock.call(b"AT")]
+
+
+def test_gsm_serial_protocol_keeps_draining_after_a_callback_raises():
+    handler = mock.MagicMock()
+    handler.on_message.side_effect = [ValueError("bad line"), None]
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b"\xff\r\nOK\r\n")
+
+    assert handler.on_message.call_args_list == [mock.call(b"\xff"), mock.call(b"OK")]
+    assert protocol.buffer == b""
+
+
+def test_gsm_serial_protocol_discards_an_oversized_partial_frame():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b"x" * (MAX_LINE_LENGTH + 1))
+
+    handler.on_message.assert_not_called()
+    assert protocol.buffer == b""
+
+
+def test_gsm_serial_protocol_keeps_a_whitespace_only_line():
+    """An SMS body of a single space is data, not framing noise."""
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+
+    protocol.data_received(b" \r\n")
+
+    handler.on_message.assert_called_once_with(b" ")
+
+
+@pytest.mark.asyncio
+async def test_gsm_serial_protocol_reset_framing_clears_echo_expectation():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+
+    await protocol.send_message(b"AT")
+    protocol.reset_framing()
+    protocol.data_received(b"AT\r\n")
+
+    handler.on_message.assert_called_once_with(b"AT")

--- a/tests/connection/gsm/test_protocol.py
+++ b/tests/connection/gsm/test_protocol.py
@@ -11,7 +11,6 @@ from paradox.connections.gsm.protocol import (
 )
 
 
-# Test GsmSerialProtocol class
 @pytest.mark.asyncio
 async def test_gsm_serial_protocol():
     handler = mock.MagicMock()

--- a/tests/connection/gsm/test_protocol.py
+++ b/tests/connection/gsm/test_protocol.py
@@ -18,7 +18,7 @@ async def test_gsm_serial_protocol():
     handler.on_connection.assert_called_once()
 
     message = b"test_message"
-    await protocol.send_message(message)
+    protocol.send_message(message)
     transport.write.assert_called_once_with(message + b"\r\n")
 
     recv_data = b"test_data\r\n"
@@ -57,7 +57,7 @@ async def test_gsm_serial_protocol_drops_echoed_message():
     protocol = GsmSerialProtocol(handler)
     protocol.connection_made(mock.MagicMock())
 
-    await protocol.send_message(b"AT")
+    protocol.send_message(b"AT")
     protocol.data_received(b"AT\r\nOK\r\n")
 
     handler.on_message.assert_called_once_with(b"OK")
@@ -70,7 +70,7 @@ async def test_gsm_serial_protocol_drops_cr_terminated_echo():
     protocol = GsmSerialProtocol(handler)
     protocol.connection_made(mock.MagicMock())
 
-    await protocol.send_message(b"AT")
+    protocol.send_message(b"AT")
     protocol.data_received(b"AT\r\r\nOK\r\n")
 
     handler.on_message.assert_called_once_with(b"OK")
@@ -83,7 +83,7 @@ async def test_gsm_serial_protocol_echo_expectation_is_not_sticky():
     protocol = GsmSerialProtocol(handler)
     protocol.connection_made(mock.MagicMock())
 
-    await protocol.send_message(b"AT+CUSD=1")
+    protocol.send_message(b"AT+CUSD=1")
     protocol.data_received(b"OK\r\n")
     protocol.data_received(b"AT+CUSD=1\r\n")
 
@@ -99,7 +99,7 @@ async def test_gsm_serial_protocol_only_checks_the_first_frame_for_echo():
     protocol = GsmSerialProtocol(handler)
     protocol.connection_made(mock.MagicMock())
 
-    await protocol.send_message(b"AT")
+    protocol.send_message(b"AT")
     protocol.data_received(b"OK\r\nAT\r\n")
 
     assert handler.on_message.call_args_list == [mock.call(b"OK"), mock.call(b"AT")]
@@ -142,7 +142,7 @@ async def test_gsm_serial_protocol_reset_framing_clears_echo_expectation():
     protocol = GsmSerialProtocol(handler)
     protocol.connection_made(mock.MagicMock())
 
-    await protocol.send_message(b"AT")
+    protocol.send_message(b"AT")
     protocol.reset_framing()
     protocol.data_received(b"AT\r\n")
 

--- a/tests/connection/gsm/test_protocol.py
+++ b/tests/connection/gsm/test_protocol.py
@@ -4,7 +4,11 @@ from unittest import mock
 
 import pytest
 
-from paradox.connections.gsm.protocol import MAX_LINE_LENGTH, GsmSerialProtocol
+from paradox.connections.gsm.protocol import (
+    MAX_LINE_LENGTH,
+    PROMPT,
+    GsmSerialProtocol,
+)
 
 
 # Test GsmSerialProtocol class
@@ -147,3 +151,86 @@ async def test_gsm_serial_protocol_reset_framing_clears_echo_expectation():
     protocol.data_received(b"AT\r\n")
 
     handler.on_message.assert_called_once_with(b"AT")
+
+
+@pytest.fixture
+async def connected_protocol():
+    handler = mock.MagicMock()
+    protocol = GsmSerialProtocol(handler)
+    protocol.connection_made(mock.MagicMock())
+    handler.reset_mock()
+    return protocol
+
+
+@pytest.mark.asyncio
+async def test_the_sms_prompt_is_surfaced_when_expected(connected_protocol):
+    """ "> " carries no terminator, so the framer alone can never emit it."""
+    connected_protocol.expect_prompt()
+
+    connected_protocol.data_received(b"\r\n> ")
+
+    connected_protocol.handler.on_message.assert_called_once_with(PROMPT)
+    assert connected_protocol.buffer == b""
+
+
+@pytest.mark.asyncio
+async def test_the_sms_prompt_is_ignored_when_not_expected(connected_protocol):
+    """Unarmed, "> " is just a line that has not finished arriving."""
+    connected_protocol.data_received(b"\r\n> ")
+
+    connected_protocol.handler.on_message.assert_not_called()
+    assert connected_protocol.buffer == b"> "
+
+
+@pytest.mark.asyncio
+async def test_the_sms_prompt_expectation_is_one_shot(connected_protocol):
+    connected_protocol.expect_prompt()
+    connected_protocol.data_received(b"\r\n> ")
+    connected_protocol.handler.reset_mock()
+
+    connected_protocol.data_received(b"> ")
+
+    connected_protocol.handler.on_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_lines_are_still_delivered_while_a_prompt_is_expected(connected_protocol):
+    connected_protocol.expect_prompt()
+
+    connected_protocol.data_received(b"+CMTI: 1\r\n> ")
+
+    assert [
+        c.args[0] for c in connected_protocol.handler.on_message.call_args_list
+    ] == [
+        b"+CMTI: 1",
+        PROMPT,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_partial_line_is_not_mistaken_for_a_prompt(connected_protocol):
+    connected_protocol.expect_prompt()
+
+    connected_protocol.data_received(b"+CMGS")
+    connected_protocol.handler.on_message.assert_not_called()
+
+    connected_protocol.data_received(b": 42\r\n")
+    connected_protocol.handler.on_message.assert_called_once_with(b"+CMGS: 42")
+
+
+@pytest.mark.asyncio
+async def test_send_raw_appends_no_terminator(connected_protocol):
+    """An SMS body ends with Ctrl-Z; a CRLF would add a blank line to it."""
+    connected_protocol.send_raw(b"body\x1a")
+
+    connected_protocol.transport.write.assert_called_once_with(b"body\x1a")
+
+
+@pytest.mark.asyncio
+async def test_reset_framing_disarms_the_prompt(connected_protocol):
+    connected_protocol.expect_prompt()
+    connected_protocol.reset_framing()
+
+    connected_protocol.data_received(b"\r\n> ")
+
+    connected_protocol.handler.on_message.assert_not_called()

--- a/tests/connection/test_line_framing.py
+++ b/tests/connection/test_line_framing.py
@@ -11,7 +11,7 @@ MAX_LINE_LENGTH = DEFAULT_MAX_LINE_LENGTH
 def framer():
     """A framer configured the way PRT3 uses it."""
     return LineFramer(
-        terminator=b"\r", max_line_length=MAX_LINE_LENGTH, drop_whitespace_lines=True
+        terminator=b"\r", max_line_length=MAX_LINE_LENGTH, drop_blank_lines=True
     )
 
 

--- a/tests/connection/test_line_framing.py
+++ b/tests/connection/test_line_framing.py
@@ -11,7 +11,7 @@ MAX_LINE_LENGTH = DEFAULT_MAX_LINE_LENGTH
 def framer():
     """A framer configured the way PRT3 uses it."""
     return LineFramer(
-        terminator=b"\r", max_line_length=MAX_LINE_LENGTH, drop_blank_lines=True
+        terminator=b"\r", max_line_length=MAX_LINE_LENGTH, drop_whitespace_lines=True
     )
 
 
@@ -65,7 +65,24 @@ def test_overflow_discards_the_buffer(framer):
 
 
 def test_recovers_after_overflow(framer):
+    """The first terminator after an overrun ends the discarded line."""
     lines(framer, b"x" * (MAX_LINE_LENGTH + 1))
+
+    # b"tail\r" is the remainder of the line that overran, not a line.
+    assert lines(framer, b"tail\rA\r") == [b"A\r"]
+
+
+def test_overflow_suffix_is_not_emitted_as_a_line(framer):
+    """Without a resync the corrupt tail looked like a whole line."""
+    lines(framer, b"G001N" + b"x" * MAX_LINE_LENGTH)
+
+    assert lines(framer, b"001\r") == []
+
+
+def test_reset_clears_the_resync_state(framer):
+    lines(framer, b"x" * (MAX_LINE_LENGTH + 1))
+    framer.reset()
+
     assert lines(framer, b"A\r") == [b"A\r"]
 
 

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -3,7 +3,9 @@ from unittest import mock
 
 import pytest
 
+from paradox.config import config as cfg
 from paradox.connections.gsm.connection import GsmSerialConnection
+from paradox.event import EventLevel
 from paradox.interfaces.text.gsm import GSMTextInterface
 
 
@@ -101,3 +103,156 @@ async def test_gsm_text_interface_stop_closes_the_port(connected_gsm_connection)
     close.assert_awaited_once()
     assert interface.port is None
     assert not interface.modem_connected
+
+
+@pytest.fixture
+async def gsm_interface(connected_gsm_connection):
+    interface = GSMTextInterface(mock.MagicMock())
+    interface.port = connected_gsm_connection
+    interface.modem_connected = True
+    connected_gsm_connection.set_recv_callback(interface.data_received)
+    return interface
+
+
+async def settle(iterations=6):
+    """Give scheduled tasks room to run without depending on wall-clock time."""
+    for _ in range(iterations):
+        await asyncio.sleep(0)
+
+
+def modem_says(comm, *lines):
+    """Feed modem output through the real protocol, as the serial port would."""
+    for line in lines:
+        comm._protocol.data_received(line)
+
+
+@pytest.mark.asyncio
+async def test_data_received_declines_command_replies():
+    """Lines the interface does not consume must reach the command waiter."""
+    interface = GSMTextInterface(mock.MagicMock())
+
+    assert interface.data_received(b"OK") is False
+    assert interface.data_received(b"+CMGS: 42") is False
+    assert interface.data_received(b"ERROR") is False
+
+
+@pytest.mark.asyncio
+async def test_data_received_consumes_unsolicited_results():
+    interface = GSMTextInterface(mock.MagicMock())
+
+    assert interface.data_received(b"+CUSD: 1") is True
+    assert interface.data_received(b'+CMT: "+1","","24/09/17,10:30:00+32"') is True
+    assert interface.data_received(b"body") is True
+
+
+@pytest.mark.asyncio
+async def test_send_message_is_synchronous(gsm_interface):
+    """An async override left every notification as a dropped coroutine."""
+    assert not asyncio.iscoroutinefunction(gsm_interface.send_message)
+
+
+@pytest.mark.asyncio
+async def test_send_message_schedules_a_send_to_every_contact(gsm_interface):
+    with mock.patch.object(cfg, "GSM_CONTACTS", ["+1", "+2"]), mock.patch.object(
+        gsm_interface, "_send_sms", new_callable=mock.AsyncMock
+    ) as send_sms:
+        gsm_interface.send_message("Alarm!", EventLevel.INFO)
+        await settle()
+
+    assert [c.args for c in send_sms.await_args_list] == [
+        ("+1", "Alarm!"),
+        ("+2", "Alarm!"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_message_is_a_no_op_while_disconnected(gsm_interface):
+    gsm_interface.modem_connected = False
+
+    with mock.patch.object(
+        gsm_interface, "_send_sms", new_callable=mock.AsyncMock
+    ) as send_sms:
+        gsm_interface.send_message("Alarm!", EventLevel.INFO)
+        await settle()
+
+    send_sms.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sms_is_a_two_stage_exchange(gsm_interface):
+    """Sending command and body together leaves the modem stuck in entry mode."""
+    comm = gsm_interface.port
+
+    with mock.patch.object(comm._protocol, "transport") as transport:
+        task = asyncio.ensure_future(gsm_interface._send_sms("+1234567890", "Alarm!"))
+        await settle()
+
+        # Stage one: the command, answered by an unterminated entry prompt.
+        transport.write.assert_called_once_with(b'AT+CMGS="+1234567890"\r\n')
+        transport.write.reset_mock()
+
+        modem_says(comm, b"\r\n> ")
+        await settle()
+
+        # Stage two: the body, ended by Ctrl-Z and with no line terminator.
+        transport.write.assert_called_once_with(b"Alarm!\x1a")
+
+        modem_says(comm, b"+CMGS: 42\r\nOK\r\n")
+        await task
+
+    assert comm.queue.empty()
+
+
+@pytest.mark.asyncio
+async def test_sms_failure_is_reported(gsm_interface):
+    comm = gsm_interface.port
+
+    with mock.patch.object(comm._protocol, "transport"):
+        task = asyncio.ensure_future(gsm_interface._send_sms("+1234567890", "Alarm!"))
+        await settle()
+        modem_says(comm, b"\r\n> ")
+        await settle()
+        modem_says(comm, b"+CMS ERROR: 500\r\n")
+
+        with pytest.raises(ValueError, match="rejected"):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_entry_mode_is_abandoned_when_no_prompt_arrives(gsm_interface):
+    comm = gsm_interface.port
+
+    with mock.patch.object(comm._protocol, "transport") as transport:
+        task = asyncio.ensure_future(gsm_interface._send_sms("+1234567890", "Alarm!"))
+        await settle()
+        transport.write.reset_mock()
+
+        modem_says(comm, b"+CMS ERROR: 310\r\n")
+
+        with pytest.raises(ValueError, match="did not ask"):
+            await task
+
+    # ESC, so the next command is not swallowed as SMS text.
+    transport.write.assert_called_once_with(b"\x1b")
+
+
+@pytest.mark.asyncio
+async def test_unsolicited_lines_do_not_satisfy_a_pending_command(gsm_interface):
+    """An SMS arriving mid-send must not be mistaken for the modem's reply."""
+    comm = gsm_interface.port
+
+    with mock.patch.object(comm._protocol, "transport") as transport:
+        task = asyncio.ensure_future(gsm_interface._send_sms("+1234567890", "Alarm!"))
+        await settle()
+        transport.write.reset_mock()
+
+        modem_says(comm, b'+CUSD: 1,"registered",0\r\n')
+        await settle()
+        transport.write.assert_not_called()
+
+        modem_says(comm, b"\r\n> ")
+        await settle()
+        transport.write.assert_called_once_with(b"Alarm!\x1a")
+
+        modem_says(comm, b"OK\r\n")
+        await task

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -30,7 +30,6 @@ async def connected_gsm_connection():
     return comm
 
 
-# Test GSMTextInterface class
 @pytest.mark.asyncio
 async def test_gsm_text_interface(connected_gsm_connection):
     alarm = mock.MagicMock()
@@ -50,9 +49,6 @@ async def test_gsm_text_interface(connected_gsm_connection):
     data = b"+CMT: test_data"
     interface.data_received(data)
     assert interface.message_cmt == data.decode()
-
-    # level = EventLevel.INFO
-    # await interface.send_message("bla", level)
 
     header = '+CMT: "+1234567890","","24/09/17,10:30:00+32"'
     text = "partition outside arm"

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -3,22 +3,13 @@ from unittest import mock
 
 import pytest
 
-from paradox.interfaces.text.gsm import (
-    MAX_LINE_LENGTH,
-    GsmSerialProtocol,
-    GSMTextInterface,
-    SerialCommunication,
-)
+from paradox.connections.gsm.connection import GsmSerialConnection
+from paradox.interfaces.text.gsm import GSMTextInterface
 
 
 @pytest.fixture
-async def connected_serial_communication():
-    port = "test_port"
-    baud = 9600
-    timeout = 5
-    comm = SerialCommunication(port, baud, timeout)
-
-    assert comm.queue.empty()
+async def connected_gsm_connection():
+    comm = GsmSerialConnection("test_port", 9600, 5)
 
     async def mocked_create_serial_connection(loop, protocol_factory, *args, **kwargs):
         transport = mock.Mock()
@@ -26,189 +17,20 @@ async def connected_serial_communication():
         asyncio.get_event_loop().call_soon(protocol.connection_made, transport)
         return (transport, protocol)
 
-    with mock.patch(
+    with mock.patch("os.access", return_value=True), mock.patch(
         "serial_asyncio.create_serial_connection",
         new_callable=mock.AsyncMock,
         side_effect=mocked_create_serial_connection,
     ):
         asyncio.get_event_loop().call_soon(comm.on_connection)
-        result = await comm.connect()
-        assert result
-
-    assert comm.connected
+        assert await comm.connect()
 
     return comm
 
 
-# Test GsmSerialProtocol class
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-
-    transport = mock.MagicMock()
-    protocol.connection_made(transport)
-    handler.on_connection.assert_called_once()
-
-    message = b"test_message"
-    await protocol.send_message(message)
-    transport.write.assert_called_once_with(message + b"\r\n")
-
-    recv_data = b"test_data\r\n"
-    protocol.data_received(recv_data)
-    handler.on_message.assert_called_once_with(b"test_data")
-
-    exc = Exception("test_exception")
-    protocol.connection_lost(exc)
-    handler.on_connection_loss.assert_called_once_with()
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_reassembles_split_frames():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    protocol.data_received(b"par")
-    handler.on_message.assert_not_called()
-
-    protocol.data_received(b"tial\r\n\r\nOK\r\ntrail")
-
-    assert handler.on_message.call_args_list == [
-        mock.call(b"partial"),
-        mock.call(b"OK"),
-    ]
-    assert protocol.buffer == b"trail"
-
-    protocol.reset_framing()
-    assert protocol.buffer == b""
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_drops_echoed_message():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.data_received(b"AT\r\nOK\r\n")
-
-    handler.on_message.assert_called_once_with(b"OK")
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_drops_cr_terminated_echo():
-    """Many V.25ter modems echo the command terminated by a bare CR."""
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.data_received(b"AT\r\r\nOK\r\n")
-
-    handler.on_message.assert_called_once_with(b"OK")
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_echo_expectation_is_not_sticky():
-    """Echo is off after ATE0, so the expectation must die with the response."""
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT+CUSD=1")
-    protocol.data_received(b"OK\r\n")
-    protocol.data_received(b"AT+CUSD=1\r\n")
-
-    assert handler.on_message.call_args_list == [
-        mock.call(b"OK"),
-        mock.call(b"AT+CUSD=1"),
-    ]
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_only_checks_the_first_frame_for_echo():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.data_received(b"OK\r\nAT\r\n")
-
-    assert handler.on_message.call_args_list == [mock.call(b"OK"), mock.call(b"AT")]
-
-
-def test_gsm_serial_protocol_keeps_draining_after_a_callback_raises():
-    handler = mock.MagicMock()
-    handler.on_message.side_effect = [ValueError("bad line"), None]
-    protocol = GsmSerialProtocol(handler)
-
-    protocol.data_received(b"\xff\r\nOK\r\n")
-
-    assert handler.on_message.call_args_list == [mock.call(b"\xff"), mock.call(b"OK")]
-    assert protocol.buffer == b""
-
-
-def test_gsm_serial_protocol_discards_an_oversized_partial_frame():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-
-    protocol.data_received(b"x" * (MAX_LINE_LENGTH + 1))
-
-    handler.on_message.assert_not_called()
-    assert protocol.buffer == b""
-
-
-def test_gsm_serial_protocol_keeps_a_whitespace_only_line():
-    """An SMS body of a single space is data, not framing noise."""
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-
-    protocol.data_received(b" \r\n")
-
-    handler.on_message.assert_called_once_with(b" ")
-
-
-@pytest.mark.asyncio
-async def test_gsm_serial_protocol_reset_framing_clears_echo_expectation():
-    handler = mock.MagicMock()
-    protocol = GsmSerialProtocol(handler)
-    protocol.connection_made(mock.MagicMock())
-
-    await protocol.send_message(b"AT")
-    protocol.reset_framing()
-    protocol.data_received(b"AT\r\n")
-
-    handler.on_message.assert_called_once_with(b"AT")
-
-
-# Test SerialCommunication class
-@pytest.mark.asyncio
-async def test_serial_communication(connected_serial_communication):
-    comm = connected_serial_communication
-
-    write_message = b"write_message"
-    write_response_message = b"write_response_message"
-    read_message = b"read_message"
-
-    asyncio.get_event_loop().call_soon(comm.on_message, write_response_message)
-    result = await comm.write(write_message)
-    assert result == write_response_message
-
-    asyncio.get_event_loop().call_soon(comm.on_message, read_message)
-    await comm.read()
-    assert comm.queue.empty()
-
-    callback = mock.MagicMock()
-    comm.set_recv_callback(callback)
-    assert comm.recv_callback == callback
-    comm.on_message(read_message)
-    callback.assert_called_once_with(read_message)
-
-
 # Test GSMTextInterface class
 @pytest.mark.asyncio
-async def test_gsm_text_interface(connected_serial_communication):
+async def test_gsm_text_interface(connected_gsm_connection):
     alarm = mock.MagicMock()
     event = asyncio.Event()
 
@@ -220,7 +42,7 @@ async def test_gsm_text_interface(connected_serial_communication):
         return True
 
     interface = GSMTextInterface(alarm)
-    interface.port = connected_serial_communication
+    interface.port = connected_gsm_connection
     interface.modem_connected = True
 
     data = b"+CMT: test_data"
@@ -262,3 +84,21 @@ async def test_gsm_text_interface_survives_a_malformed_cusd():
     interface = GSMTextInterface(mock.MagicMock())
 
     assert interface.data_received(b"+CUSD: not-json")
+
+
+@pytest.mark.asyncio
+async def test_gsm_text_interface_stop_closes_the_port(connected_gsm_connection):
+    """stop() used to be a no-op, leaking the serial port for the process."""
+    interface = GSMTextInterface(mock.MagicMock())
+    interface.port = connected_gsm_connection
+    interface.modem_connected = True
+
+    with mock.patch.object(
+        connected_gsm_connection, "close", new_callable=mock.AsyncMock
+    ) as close:
+        interface.stop()
+        await asyncio.sleep(0)
+
+    close.assert_awaited_once()
+    assert interface.port is None
+    assert not interface.modem_connected

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -6,6 +6,7 @@ import pytest
 from paradox.config import config as cfg
 from paradox.connections.gsm.connection import GsmSerialConnection
 from paradox.event import EventLevel
+from paradox.interfaces.text import gsm
 from paradox.interfaces.text.gsm import GSMTextInterface
 
 
@@ -256,3 +257,120 @@ async def test_unsolicited_lines_do_not_satisfy_a_pending_command(gsm_interface)
 
         modem_says(comm, b"OK\r\n")
         await task
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sends_are_serialised(gsm_interface):
+    """Two AT commands in flight at once make the second the first SMS's body."""
+    comm = gsm_interface.port
+
+    with mock.patch.object(comm._protocol, "transport") as transport:
+        first = asyncio.ensure_future(gsm_interface._send_sms("+1", "one"))
+        second = asyncio.ensure_future(gsm_interface._send_sms("+2", "two"))
+        await settle()
+
+        # Only the first exchange has reached the modem.
+        assert [c.args[0] for c in transport.write.call_args_list] == [
+            b'AT+CMGS="+1"\r\n'
+        ]
+
+        modem_says(comm, b"\r\n> ")
+        await settle()
+        modem_says(comm, b"OK\r\n")
+        await first
+
+        # The second waits its turn rather than interleaving.
+        await settle()
+        assert transport.write.call_args_list[-1].args[0] == b'AT+CMGS="+2"\r\n'
+
+        modem_says(comm, b"\r\n> ")
+        await settle()
+        modem_says(comm, b"OK\r\n")
+        await second
+
+
+@pytest.mark.asyncio
+async def test_at_command_reports_a_rejection_immediately(gsm_interface):
+    """An ERROR used to be swallowed and cost a full command timeout."""
+    comm = gsm_interface.port
+    comm.set_recv_callback(None)
+
+    with mock.patch.object(comm._protocol, "transport"):
+        task = asyncio.ensure_future(gsm_interface._at_command(b"AT+CUSD=1"))
+        await settle()
+        modem_says(comm, b"+CME ERROR: operation not supported\r\n")
+
+        with pytest.raises(ValueError, match="rejected"):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_at_command_skips_informational_lines(gsm_interface):
+    comm = gsm_interface.port
+    comm.set_recv_callback(None)
+
+    with mock.patch.object(comm._protocol, "transport"):
+        task = asyncio.ensure_future(gsm_interface._at_command(b"AT+CSQ"))
+        await settle()
+        modem_says(comm, b"+CSQ: 19,99\r\nOK\r\n")
+
+        assert await task == b"OK"
+
+
+@pytest.mark.asyncio
+async def test_run_reconnects_after_the_modem_drops(gsm_interface):
+    """on_connection_loss clears only the transport's flag; run() must notice."""
+    connects = []
+
+    async def fake_connect():
+        connects.append(True)
+        gsm_interface.modem_connected = True
+        gsm_interface.port.connected = True
+        return True
+
+    with mock.patch.object(gsm, "MODEM_POLL_INTERVAL", 0), mock.patch.object(
+        gsm_interface, "connect", side_effect=fake_connect
+    ):
+        task = asyncio.ensure_future(gsm_interface.run())
+        await settle()
+        assert connects == []  # already connected, nothing to do
+
+        gsm_interface.port.connected = False  # modem unplugged
+        await settle()
+
+        task.cancel()
+
+    assert connects, "run() never reconnected after the port dropped"
+
+
+@pytest.mark.asyncio
+async def test_connect_closes_the_previous_port(gsm_interface):
+    """A failed retry used to leak the previous connection object."""
+    old = gsm_interface.port
+
+    with mock.patch.object(
+        old, "close", new_callable=mock.AsyncMock
+    ) as close, mock.patch.object(
+        gsm.GsmSerialConnection, "connect", new_callable=mock.AsyncMock
+    ) as connect:
+        connect.return_value = False
+        assert await gsm_interface.connect() is False
+
+    close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_in_flight_sends(gsm_interface):
+    comm = gsm_interface.port
+
+    with mock.patch.object(comm._protocol, "transport"), mock.patch.object(
+        cfg, "GSM_CONTACTS", ["+1"]
+    ):
+        gsm_interface.send_message("Alarm!", EventLevel.INFO)
+        await settle()
+        task = next(iter(gsm_interface._send_tasks))
+
+        gsm_interface.stop()
+        await settle()
+
+    assert task.cancelled()

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -22,7 +22,6 @@ async def connected_gsm_connection():
         new_callable=mock.AsyncMock,
         side_effect=mocked_create_serial_connection,
     ):
-        asyncio.get_event_loop().call_soon(comm.on_connection)
         assert await comm.connect()
 
     return comm

--- a/tests/interfaces/test_gsm.py
+++ b/tests/interfaces/test_gsm.py
@@ -374,3 +374,38 @@ async def test_stop_cancels_in_flight_sends(gsm_interface):
         await settle()
 
     assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_a_stale_ok_does_not_satisfy_the_next_command(gsm_interface):
+    """The late answer to a timed-out command used to be handed to the next."""
+    comm = gsm_interface.port
+    comm.set_recv_callback(None)
+
+    with mock.patch.object(comm._protocol, "transport"):
+        with pytest.raises(asyncio.TimeoutError):
+            await gsm_interface._at_command(b"AT+A", timeout=0.01)
+
+        modem_says(comm, b"OK\r\n")  # A's answer, arriving too late
+
+        task = asyncio.ensure_future(gsm_interface._at_command(b"AT+B"))
+        await settle()
+        assert not task.done(), "the stale OK was taken as B's reply"
+
+        modem_says(comm, b"OK\r\n")
+        assert await task == b"OK"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_line_is_not_mistaken_for_the_sms_prompt(gsm_interface):
+    comm = gsm_interface.port
+    comm.on_message(b"stale")  # left behind by an earlier timeout
+
+    with mock.patch.object(comm._protocol, "transport"):
+        task = asyncio.ensure_future(gsm_interface._send_sms("+1", "hi"))
+        await settle()
+        modem_says(comm, b"\r\n> ")
+        await settle()
+        modem_says(comm, b"OK\r\n")
+
+        await task


### PR DESCRIPTION
Follow-up to #613 and #614, from the post-merge critical review.

### :warning: This also restores #614

**#614's content never reached `dev`.** It was stacked on `fix/611-gsm-line-framing` and GitHub marked it MERGED when it merged into *that* branch — but #613 was merged to `dev` beforehand, so `paradox/connections/gsm/` does not exist on `dev` today. The first commit here is a cherry-pick of `9803043` to bring it back.

```
git merge-base --is-ancestor 9803043 origin/dev   # false
```

### Fixes

**1. `send_message` was async but awaited nothing — the root cause of item 7**

`ConnectionProtocol.send_message` is a *synchronous* abstract method. `GsmSerialProtocol` overrode it as `async def` around a bare `transport.write()`. That LSP violation is *why* it collided with `serial.protocol.SerialConnectionProtocol` in the first place: #613 renamed the class to dodge the collision, and #614 then had to override `Connection.write()` to raise `NotImplementedError` so nobody could reach the un-awaited coroutine.

Making it synchronous deletes both workarounds. `send_command()` now uses the inherited `Connection.write()`, and the missing `check_active()` guard is in place.

**2. `LineFramer` emitted the tail of an over-long line as a valid frame**

Before, after discarding an overrun the framer would treat whatever followed up to the next terminator as a complete line:

```python
f = LineFramer(terminator=b"\r\n", max_line_length=8)
f.feed(b"X" * 12)          # [] - discarded, good
f.feed(b"TAIL\r\nOK\r\n")  # [b"TAIL", b"OK"]  <- b"TAIL" is corrupt
```

It now resynchronises: bytes up to and including the next terminator are dropped, so only `b"OK"` comes through. `reset()` clears the resync state.

**3. `drop_blank_lines` → `drop_whitespace_lines`**

The old name conflated two things. Empty payloads are now *always* skipped; skipping whitespace-only lines is the opt-in behaviour the name now describes. PRT3 is the only caller and keeps its existing semantics.

**4. `connect()` did not actually bound the port open**

`open_timeout` was scheduled with `call_later`, but it only resolves `connected_future` — useless if `create_serial_connection` is what hangs, since `connect()` is not awaiting that future yet. The open is now wrapped in `asyncio.wait_for`.

### Tests

1633 passing. New coverage for the overflow resync, `reset()` clearing it, the bounded open, and `write()` reaching the transport (replacing the `NotImplementedError` test).

### 5. GSM outbound SMS never worked at all

Not a regression — the code at `d347e0b`, before any of these PRs, has all three of these defects verbatim. The test for it was left commented out in `tests/interfaces/test_gsm.py`:

```python
# level = EventLevel.INFO
# await interface.send_message("bla", level)
```

**a. `send_message` was `async` over a synchronous base.** `GSMTextInterface` was the codebase's only `async` override of `AbstractTextInterface.send_message`, which `handle_notify` and `handle_panel_event` call directly. Every notification built a coroutine that nobody awaited and dropped it — the source of the `RuntimeWarning: coroutine 'GSMTextInterface.send_message' was never awaited` seen throughout the test suite. It is now synchronous and schedules the send as a task.

**b. The response queue was starved after init.** `connect()` finishes with `set_recv_callback(self.data_received)`, after which `on_message` routed *every* line to the callback and none to the queue — so `send_command()`'s `queue.get()` could never be satisfied. Even a correctly awaited SMS could only time out.

`set_recv_callback` is typed `Callable[[bytes], bool]`, but the result was discarded. Honouring it gives URC demultiplexing for free:

```python
if self.recv_callback is not None and self.recv_callback(message):
    return
self.queue.put_nowait(message)
```

`data_received` now returns `True` only for lines it consumed (`+CMT` and its body, `+CUSD`); `OK`, `ERROR` and `+CMGS:` fall through to the waiting command.

**c. `AT+CMGS` was sent as one blob.** Text-mode SMS is a two-stage exchange: the modem answers with a `> ` entry prompt and only then accepts the body, terminated by Ctrl-Z rather than CRLF. Sending both at once leaves the modem sitting in entry mode with nothing sent.

The prompt is `\r\n> ` — **unterminated**, so `LineFramer` can never surface it. `GsmSerialProtocol` gains a one-shot `expect_prompt()` that a caller arms when it knows a prompt is due; unarmed, `> ` is correctly treated as a line that has not finished arriving. Failure paths send ESC so the modem does not swallow the next command as message text.

### Tests

1654 passing, up from 1633 on `dev`. Each fix was verified to be genuinely covered by reverting it and confirming the new tests fail:

| Reverted | Failing tests |
|---|---|
| callback return value ignored | 5, incl. `test_unsolicited_lines_do_not_satisfy_a_pending_command` |
| prompt detection removed | 5, incl. `test_sms_is_a_two_stage_exchange` |

`test_sms_is_a_two_stage_exchange` drives real bytes through the real protocol and asserts the full command → prompt → body → `+CMGS:`/`OK` sequence, which is what the commented-out test was reaching for.


---

## Follow-up: rubber-duck review of the above

Reviewing the SMS work turned up five more defects. Three were confirmed by running them, not just by reading.

### 6. The command channel had no mutual exclusion (blocking)

Two notifications arriving together each schedule a send. Observed: **both commands reach the modem before either reply comes back.**

```
>>> writes before any reply: [b'AT+A\r\n', b'AT+B\r\n']
```

For `AT+CMGS` that is worse than mispaired replies — between the `> ` prompt and the Ctrl-Z the modem treats everything written as message text, so the second command becomes **the body of the first SMS**.

The lock lives in `GSMTextInterface` rather than the transport: an SMS exchange spans `send_command` + `write_raw` + `read`, so guarding it inside the connection would require a reentrant lock. It is also held across the whole init sequence, so a half-initialised modem cannot see an SMS interleaved between `ATE0` and `AT+CMGF=1`.

### 7. A stale reply satisfied the next command (blocking)

The late answer to a timed-out command sat in the queue and was handed to whatever came next:

```
>>> AT+B received: b'LATE-REPLY-TO-A'
```

`send_command` now drains before writing — anything already queued predates the command. `clear()` drains in place instead of replacing the queue object, which previously stranded any coroutine already blocked in `read()`.

### 8. `expect_prompt()` stayed armed after a timeout

Nothing disarmed it on the error paths, leaving the next unterminated line primed to be read as an SMS prompt. Now cleared in a `finally`.

### 9. A modem drop was fatal until restart

`run()` looped `while not self.modem_connected` and returned once connected. `on_connection_loss` clears the *transport's* flag but nothing ever reset the interface's, so an unplugged or reset modem meant no more alerts until PAI restarted — on an alarm interface, silently. `run()` now watches the transport and rebuilds the port, and `connect()` closes the previous one first (a failed retry used to leak the last attempt).

### 10. The init helper was dead code around a real bug

```python
while r != expected:
    r = await self.port.send_command(message)
    data = b""
    if r == b"ERROR": raise ...
    while r != expected:
        r = await self.port.read()
        data += r + b"\n"
```

The outer loop can never iterate twice (the inner one only exits when `r == expected`), `data` is accumulated and thrown away, and an `ERROR` arriving in the inner loop is ignored — so a rejected init command cost a 5 s timeout instead of reporting itself. Replaced by `_at_command()`, which shares the final-result reader with the SMS path.

Also: in-flight send tasks are now tracked, so `stop()` cancels them and the event loop keeps a strong reference (asyncio only holds a weak one).

### Tests

**1664 passing**, up from 1633 on `dev`. Every fix was verified by reverting it and confirming the new tests fail:

| Reverted | Failing test |
|---|---|
| command lock | `test_concurrent_sends_are_serialised` |
| queue drain | `test_a_stale_reply_does_not_satisfy_the_next_command` |
| prompt disarm | `test_a_timed_out_command_disarms_the_prompt` |
| reconnect check | `test_run_reconnects_after_the_modem_drops` |
| callback return value | 5 tests, incl. `test_unsolicited_lines_do_not_satisfy_a_pending_command` |
| prompt detection | 5 tests, incl. `test_sms_is_a_two_stage_exchange` |
