### PR TITLE
feat(mqtt): publish each zone as its own HA device under the panel

### DIFF
--- a/paradox/interfaces/mqtt/entities/abstract_entity.py
+++ b/paradox/interfaces/mqtt/entities/abstract_entity.py
@@ -44,6 +44,29 @@ class AbstractEntity:
             ]
         )
 
+    def _hass_device(self):
+        """Device block for the discovery payload.
+
+        Zones get their own device, linked to the panel with ``via_device`` so
+        Home Assistant nests them underneath it. Without this every zone sensor,
+        binary sensor and bypass switch lands on the panel device, which on a
+        large system is a flat list of hundreds of entities.
+
+        ``unique_id`` is deliberately untouched, so on an existing install the
+        entities are re-parented in place: entity ids, customisations and
+        history are all preserved.
+        """
+        if self.pai_entity_type != "zone":
+            return self.device
+
+        return dict(
+            identifiers=[f"Paradox_{self.device.serial_number}_zone_{self.key}"],
+            name=self.label or to_label(self.key),
+            manufacturer="Paradox",
+            model="Zone",
+            via_device=self.device.serialize()["identifiers"][0],
+        )
+
     def serialize(self):
         prefix = cfg.MQTT_HOMEASSISTANT_ENTITY_PREFIX.format_map(
             {
@@ -53,7 +76,7 @@ class AbstractEntity:
         )
         return dict(
             availability_topic=self.availability_topic,
-            device=self.device,
+            device=self._hass_device(),
             name=prefix + f"{self.entity_name}",
             unique_id=f"paradox_{self.device.serial_number}_{self.entity_id}",
             state_topic=self.state_topic,

--- a/tests/interfaces/mqtt/test_entities.py
+++ b/tests/interfaces/mqtt/test_entities.py
@@ -55,7 +55,7 @@ def test_zone_binary_sensor_serialize(mqtt_entity_factory):
         'name': 'Zone Zone 1 Open',
         'availability_topic': 'paradox/interface/availability',
         'state_topic': 'paradox/states/zones/Zone_1/open',
-        'device': _get_expected_device_block(),
+        'device': _get_expected_zone_device_block(),
         'payload_on': 'True',
         'payload_off': 'False',
         'device_class': 'motion'
@@ -129,7 +129,7 @@ def test_zone_bypass_switch_serialize(mqtt_entity_factory):
         'availability_topic': 'paradox/interface/availability',
         'state_topic': 'paradox/states/zones/Zone_1/bypassed',
         'command_topic': 'paradox/control/zones/Zone_1',
-        'device': _get_expected_device_block(),
+        'device': _get_expected_zone_device_block(),
         'state_on': 'True',
         'state_off': 'False',
         'payload_on': 'bypass',
@@ -155,6 +155,16 @@ def _get_expected_device_block():
             'model': 'EVO',
             'name': 'EVO',
             'sw_version': '6.10'
+        }
+
+
+def _get_expected_zone_device_block():
+    return {
+            'identifiers': ['Paradox_1234abcd_zone_Zone_1'],
+            'manufacturer': 'Paradox',
+            'model': 'Zone',
+            'name': 'Zone 1',
+            'via_device': 'Paradox_1234abcd'
         }
 
 

--- a/tests/interfaces/mqtt/test_homeassistant.py
+++ b/tests/interfaces/mqtt/test_homeassistant.py
@@ -45,11 +45,15 @@ async def test_hass(mocker):
         sendMessage(
             "labels_loaded",
             data=dict(
-                partition={1: dict(id=1, label="Partition 1", key="Partition_1")}
+                partition={1: dict(id=1, label="Partition 1", key="Partition_1")},
+                zone={1: dict(id=1, label="Front Door", key="Front_Door")},
             ),
         )
 
-        sendMessage("status_update", status=dict(partition={1: dict(arm=False)}))
+        sendMessage(
+            "status_update",
+            status=dict(partition={1: dict(arm=False)}, zone={1: dict(open=False)}),
+        )
 
         await asyncio.sleep(0.1)
 
@@ -95,6 +99,31 @@ async def test_hass(mocker):
                 "code_arm_required": False,
                 "code_disarm_required": False,
                 "code_trigger_required": False,
+            },
+            0,
+            True,
+        )
+
+        # A zone is published as its own device, nested under the panel via
+        # via_device, rather than being attached to the panel device directly.
+        assert_any_call_with_json(
+            interface.mqtt.publish,
+            "homeassistant/binary_sensor/aabbccdd/zone_front_door_open/config",
+            {
+                "name": "Zone Front Door Open",
+                "unique_id": "paradox_aabbccdd_zone_front_door_open",
+                "state_topic": "paradox/states/zones/Front_Door/open",
+                "availability_topic": "paradox/interface/availability",
+                "device": {
+                    "manufacturer": "Paradox",
+                    "model": "Zone",
+                    "identifiers": ["Paradox_aabbccdd_zone_Front_Door"],
+                    "name": "Front Door",
+                    "via_device": "Paradox_aabbccdd",
+                },
+                "device_class": "motion",
+                "payload_on": "True",
+                "payload_off": "False",
             },
             0,
             True,


### PR DESCRIPTION
## Problem

Every entity PAI publishes lands on a single Home Assistant device — the panel. On a system with a few dozen zones that is one device holding several hundred entities in a flat, ungrouped list, and there is no way to see "everything about the front door" in one place.

## Change

Zones get their own device block, linked back to the panel with `via_device` so Home Assistant nests them underneath it. Partitions, PGMs and system entities are untouched.

Before — every zone entity:

```json
"device": {
  "manufacturer": "Paradox", "model": "EVO192",
  "identifiers": ["Paradox_aabbccdd"],
  "name": "EVO192", "sw_version": "6.80 build 5"
}
```

After — a zone entity:

```json
"device": {
  "manufacturer": "Paradox", "model": "Zone",
  "identifiers": ["Paradox_aabbccdd_zone_Front_Door"],
  "name": "Front Door",
  "via_device": "Paradox_aabbccdd"
}
```

The zone's binary sensor, numeric sensors and bypass switch all resolve to the same device, so they group together.

## Migration safety

`unique_id` is deliberately not touched. On an existing install Home Assistant re-parents the entities in place rather than re-creating them — entity ids, customisations and recorder history are all preserved. The only visible change is where they sit in the device tree.

The zone identifier is scoped by panel serial (`Paradox_<serial>_zone_<key>`) to match the convention the panel device adopted in #592, so two panels on one broker cannot collide. Zone `key` is label-derived, so renaming a zone on the panel changes its identifier — that is the same pre-existing caveat that already applies to `unique_id`, not something this change introduces.

## Testing

- `tests/interfaces/mqtt/test_entities.py` — the two zone serialization tests now assert the nested device block; verified they fail without the source change.
- `tests/interfaces/mqtt/test_homeassistant.py` — extended the end-to-end discovery test with a zone, asserting the published payload including `via_device`.
- Full suite: 1700 passed. `flake8 --select=E9,F63,F7,F82` clean, `black`/`isort` clean.

Functionally this has been running against an MG5050 since July. The deployed build used an unscoped `Paradox_zone_<key>` identifier; this PR scopes it by serial per the note above, which is the only difference from what has been exercised in production.
